### PR TITLE
Added commands for all possible recycle bin operations

### DIFF
--- a/Commands/Base/PipeBinds/RecycleBinItemPipeBind.cs
+++ b/Commands/Base/PipeBinds/RecycleBinItemPipeBind.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.SharePoint.Client;
+
+namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
+{
+    public sealed class RecycleBinItemPipeBind
+    {
+        private RecycleBinItem _item;
+        private readonly Guid? _id;
+
+        public RecycleBinItemPipeBind()
+        {
+            _item = null;
+            _id = null;
+        }
+
+        public RecycleBinItemPipeBind(RecycleBinItem item)
+        {
+            _item = item;
+        }
+
+        public RecycleBinItemPipeBind(string id)
+        {
+            Guid guid;
+
+            if (Guid.TryParse(id, out guid))
+            {
+                _id = guid;
+            }
+            else
+            {
+                _id = null;
+            }
+        }
+
+        public RecycleBinItem Item
+        {
+            get
+            {
+                return _item;
+            }
+        }
+
+        public Guid? Id
+        {
+            get { return _id; }
+        }
+
+        internal RecycleBinItem GetRecycleBinItem(Microsoft.SharePoint.Client.Site site)
+        {
+            if (Item != null) return Item;
+            if (!_id.HasValue) return null;
+
+            _item = site.RecycleBin.GetById(_id.Value);
+            site.Context.ExecuteQueryRetry();
+            return Item;
+        }
+    }
+}

--- a/Commands/Properties/Resources.Designer.cs
+++ b/Commands/Properties/Resources.Designer.cs
@@ -70,6 +70,42 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Permanently delete all items in the first and second stage recycle bins?.
+        /// </summary>
+        internal static string ClearBothRecycleBins {
+            get {
+                return ResourceManager.GetString("ClearBothRecycleBins", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Permanently delete file &apos;{0}&apos; from the recycle bin?.
+        /// </summary>
+        internal static string ClearRecycleBinItem {
+            get {
+                return ResourceManager.GetString("ClearRecycleBinItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Permanently delete all the items in the second stage recycle bin?.
+        /// </summary>
+        internal static string ClearSecondStageRecycleBin {
+            get {
+                return ResourceManager.GetString("ClearSecondStageRecycleBin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Permanently delete the site collection previously located at &apos;{0}&apos; from the recycle bin?.
+        /// </summary>
+        internal static string ClearTenantRecycleBinItem {
+            get {
+                return ResourceManager.GetString("ClearTenantRecycleBinItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Command not executed due to healthscore value of {0}.
         /// </summary>
         internal static string CommandNotExecutedDueToHealthscoreValueOf0 {
@@ -184,6 +220,15 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         internal static string MicrosoftGraphOAuthAccessTokenExpired {
             get {
                 return ResourceManager.GetString("MicrosoftGraphOAuthAccessTokenExpired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move all items from the first stage recycle bin to the second stage recycle bin?.
+        /// </summary>
+        internal static string MoveFirstStageRecycleBinItemsToSecondStage {
+            get {
+                return ResourceManager.GetString("MoveFirstStageRecycleBinItemsToSecondStage", resourceCulture);
             }
         }
         
@@ -392,6 +437,33 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         internal static string RemoveWeb0 {
             get {
                 return ResourceManager.GetString("RemoveWeb0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore the file &apos;{0}&apos; from the recycle bin to its original location?.
+        /// </summary>
+        internal static string ResetRecycleBinItem {
+            get {
+                return ResourceManager.GetString("ResetRecycleBinItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore all items from the first and second stage recycle bins to their original locations?.
+        /// </summary>
+        internal static string ResetRecycleBinItems {
+            get {
+                return ResourceManager.GetString("ResetRecycleBinItems", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore the site collection previously located at &apos;{0}&apos; from the recycle bin to its original location?.
+        /// </summary>
+        internal static string ResetTenantRecycleBinItem {
+            get {
+                return ResourceManager.GetString("ResetTenantRecycleBinItem", resourceCulture);
             }
         }
         

--- a/Commands/Properties/Resources.resx
+++ b/Commands/Properties/Resources.resx
@@ -238,4 +238,28 @@
   <data name="ForceCreationOfExistingGroup0" xml:space="preserve">
     <value>The Unified Group with MailNickname of {0} already exists. Do you want to create another one?</value>
   </data>
+  <data name="ClearBothRecycleBins" xml:space="preserve">
+    <value>Permanently delete all items in the first and second stage recycle bins?</value>
+  </data>
+  <data name="ClearRecycleBinItem" xml:space="preserve">
+    <value>Permanently delete file '{0}' from the recycle bin?</value>
+  </data>
+  <data name="ClearSecondStageRecycleBin" xml:space="preserve">
+    <value>Permanently delete all the items in the second stage recycle bin?</value>
+  </data>
+  <data name="ClearTenantRecycleBinItem" xml:space="preserve">
+    <value>Permanently delete the site collection previously located at '{0}' from the recycle bin?</value>
+  </data>
+  <data name="MoveFirstStageRecycleBinItemsToSecondStage" xml:space="preserve">
+    <value>Move all items from the first stage recycle bin to the second stage recycle bin?</value>
+  </data>
+  <data name="ResetRecycleBinItem" xml:space="preserve">
+    <value>Restore the file '{0}' from the recycle bin to its original location?</value>
+  </data>
+  <data name="ResetRecycleBinItems" xml:space="preserve">
+    <value>Restore all items from the first and second stage recycle bins to their original locations?</value>
+  </data>
+  <data name="ResetTenantRecycleBinItem" xml:space="preserve">
+    <value>Restore the site collection previously located at '{0}' from the recycle bin to its original location?</value>
+  </data>
 </root>

--- a/Commands/RecycleBin/ClearRecycleBinItem.cs
+++ b/Commands/RecycleBin/ClearRecycleBinItem.cs
@@ -1,0 +1,45 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Clear, "PnpRecycleBinItem")]
+    [CmdletHelp("Permanently deletes the provided recycle bin item",
+        Category = CmdletHelpCategory.RecycleBin)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPRecycleBinItems | ? FileLeafName -like ""*.docx"" | Clear-PnpRecycleBinItem",
+        Remarks = "Permanently deletes all the items in the first and second stage recycle bins of which the file names have the .docx extension",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnpRecycleBinItem -Identity 72e4d749-d750-4989-b727-523d6726e442",
+        Remarks = "Permanently deletes the recycle bin item with Id 72e4d749-d750-4989-b727-523d6726e442 from the recycle bin",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnpRecycleBinItem -Identity $item -Force",
+        Remarks = "Permanently deletes the recycle bin item stored under variable $item from the recycle bin without asking for confirmation from the end user first",
+        SortOrder = 3)]
+    public class ClearRecycleBinItem : SPOCmdlet
+    {
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to permanently delete the recycle bin item")]
+        public SwitchParameter Force;
+
+        [Parameter(Mandatory = true, HelpMessage = "Id of the recycle bin item or the recycle bin item itself to permanently delete", ValueFromPipeline = true)]
+        public RecycleBinItemPipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            var recycleBinItem = Identity.GetRecycleBinItem(ClientContext.Site);
+            ClientContext.Load(recycleBinItem);
+            ClientContext.ExecuteQueryRetry();
+
+            if (Force || ShouldContinue(string.Format(Resources.ClearRecycleBinItem, recycleBinItem.LeafName), Resources.Confirm))
+            {
+                recycleBinItem.DeleteObject();
+                ClientContext.ExecuteQueryRetry();
+            }      
+        }
+    }
+}

--- a/Commands/RecycleBin/ClearRecycleBinItems.cs
+++ b/Commands/RecycleBin/ClearRecycleBinItems.cs
@@ -1,0 +1,51 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Clear, "PnpRecycleBinItems")]
+    [CmdletHelp("Permanently deletes all the items in the recycle bins from the context",
+        Category = CmdletHelpCategory.RecycleBin)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnpRecycleBinItems",
+        Remarks = "Permanently deletes all the items in the first and second stage recycle bins from the context",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnpRecycleBinItems -SecondStageOnly",
+        Remarks = "Permanently deletes all the items only in the second stage recycle bin from the context",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnpRecycleBinItems -Force",
+        Remarks = "Permanently deletes all the items in the first and second stage recycle bins from the context without asking for confirmation from the end user first",
+        SortOrder = 3)]
+    public class ClearRecycleBinItems : SPOCmdlet
+    {
+        [Parameter(Mandatory = false, HelpMessage = "If provided, only all the items in the second stage recycle bin will be cleared")]
+        public SwitchParameter SecondStageOnly = false;
+
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to clear the recycle bin")]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (SecondStageOnly)
+            {
+                if (Force || ShouldContinue(Resources.ClearSecondStageRecycleBin, Resources.Confirm))
+                {
+                    ClientContext.Site.RecycleBin.DeleteAllSecondStageItems();
+                    ClientContext.ExecuteQueryRetry();
+                }
+            }
+            else
+            {
+                if (Force || ShouldContinue(Resources.ClearBothRecycleBins, Resources.Confirm))
+                {
+                    ClientContext.Site.RecycleBin.DeleteAll();
+                    ClientContext.ExecuteQueryRetry();
+                }
+            }            
+        }
+    }
+}

--- a/Commands/RecycleBin/ClearTenantRecycleBinItem.cs
+++ b/Commands/RecycleBin/ClearTenantRecycleBinItem.cs
@@ -1,0 +1,51 @@
+﻿using System.Management.Automation;
+using System.Threading;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Clear, "PnPTenantRecycleBinItem")]
+    [CmdletHelp("Permanently deletes a site collection from the tenant scoped recycle bin", 
+        DetailedDescription = @"The Clear-PnPTenantRecycleBinItem cmdlet allows a site collection that has been deleted and still exists in the tenant recycle bin to be permanently deleted from the recycle bin as well.", 
+        Category = CmdletHelpCategory.TenantAdmin)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso",
+        Remarks = @"This will permanently delete site collection with the url 'https://tenant.sharepoint.com/sites/contoso' from the tenant recycle bin", SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso -Wait",
+        Remarks = @"This will permanently delete site collection with the url 'https://tenant.sharepoint.com/sites/contoso' from the tenant recycle bin and will wait with executing further PowerShell commands until the operation has completed", SortOrder = 2)]
+    public class ClearTenantRecycleBinItem : SPOAdminCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "Url of the site collection to permanently delete from the tenant recycle bin", ValueFromPipeline = false)]
+        public string Url;
+
+        [Parameter(Mandatory = false, HelpMessage = "If provided, the PowerShell execution will halt until the operation has completed", ValueFromPipeline = false)]
+        public SwitchParameter Wait = false;
+
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to permanently delete the site collection from the tenant recycle bin")]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (Force || ShouldContinue(string.Format(Resources.ClearTenantRecycleBinItem, Url), Resources.Confirm))
+            {
+                var spOperation = Tenant.RemoveDeletedSite(Url);
+                Tenant.Context.Load(spOperation);
+                Tenant.Context.ExecuteQueryRetry();
+                
+                if (Wait)
+                {
+                    while (!spOperation.IsComplete)
+                    {
+                        Thread.Sleep(3000);
+                        Tenant.Context.Load(spOperation);
+                        Tenant.Context.ExecuteQueryRetry();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Commands/RecycleBin/GetRecycleBinItems.cs
+++ b/Commands/RecycleBin/GetRecycleBinItems.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Extensions;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Get, "PnPRecycleBinItems")]
+    [CmdletHelp("Returns the items in the recycle bin from the context",
+        Category = CmdletHelpCategory.RecycleBin,
+        OutputType = typeof(RecycleBinItem),
+        OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.recyclebinitem.aspx")]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPRecycleBinItems",
+        Remarks = "Returns all items in both the first and the second stage recycle bins in the current site collection",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPRecycleBinItems | ? ItemState -eq ""FirstStageRecycleBin""",
+        Remarks = "Returns all items in only the first stage recycle bin in the current site collection",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPRecycleBinItems | ? ItemState -eq ""SecondStageRecycleBin""",
+        Remarks = "Returns all items in only the second stage recycle bin in the current site collection",
+        SortOrder = 3)]
+    public class GetRecycleBinItems : SPOCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            ClientContext.Site.LoadProperties(s => s.RecycleBin);
+            
+            var recycleBinItemList = ClientContext.Site.RecycleBin.ToList();
+            WriteObject(recycleBinItemList, true);
+        }
+    }
+}

--- a/Commands/RecycleBin/MoveRecycleBinItems.cs
+++ b/Commands/RecycleBin/MoveRecycleBinItems.cs
@@ -1,0 +1,33 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Move, "PnpRecycleBinItems")]
+    [CmdletHelp("Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin",
+        Category = CmdletHelpCategory.RecycleBin)]
+    [CmdletExample(
+        Code = @"PS:> Move-PnpRecycleBinItems",
+        Remarks = "Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Move-PnpRecycleBinItems -Force",
+        Remarks = "Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin without asking for confirmation first",
+        SortOrder = 2)]
+    public class MoveRecycleBinItems : SPOCmdlet
+    {
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to move the first stage recycle bin items to the second stage")]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (Force || ShouldContinue(Resources.MoveFirstStageRecycleBinItemsToSecondStage, Resources.Confirm))
+            {
+                ClientContext.Site.RecycleBin.MoveAllToSecondStage();
+                ClientContext.ExecuteQueryRetry();
+            }                  
+        }
+    }
+}

--- a/Commands/RecycleBin/ResetRecycleBinItem.cs
+++ b/Commands/RecycleBin/ResetRecycleBinItem.cs
@@ -1,0 +1,41 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Reset, "PnpRecycleBinItem")]
+    [CmdletHelp("Restores the provided recycle bin item to its original location",
+        Category = CmdletHelpCategory.RecycleBin)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPRecycleBinItems | ? FileLeafName -like ""*.docx"" | Reset-PnpRecycleBinItem",
+        Remarks = "Restores all the items in the first and second stage recycle bins to their original location of which the filename ends with the .docx extension",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Reset-PnpRecycleBinItem -Identity 72e4d749-d750-4989-b727-523d6726e442",
+        Remarks = "Restores the recycle bin item with Id 72e4d749-d750-4989-b727-523d6726e442 to its original location",
+        SortOrder = 2)]
+    public class ResetRecycleBinItem : SPOCmdlet
+    {
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to restore the recycle bin item")]
+        public SwitchParameter Force;
+
+        [Parameter(Mandatory = true, HelpMessage = "Id of the recycle bin item or the recycle bin item itself to restore", ValueFromPipeline = true)]
+        public RecycleBinItemPipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            var recycleBinItem = Identity.GetRecycleBinItem(ClientContext.Site);
+            ClientContext.Load(recycleBinItem);
+            ClientContext.ExecuteQueryRetry();
+
+            if (Force || ShouldContinue(string.Format(Resources.ResetRecycleBinItem, recycleBinItem.LeafName), Resources.Confirm))
+            {
+                recycleBinItem.Restore();
+                ClientContext.ExecuteQueryRetry();
+            }      
+        }
+    }
+}

--- a/Commands/RecycleBin/ResetRecycleBinItems.cs
+++ b/Commands/RecycleBin/ResetRecycleBinItems.cs
@@ -1,0 +1,33 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Reset, "PnpRecycleBinItems")]
+    [CmdletHelp("Restores all the items from the first and second stage recycle bin of the current context to their original locations",
+        Category = CmdletHelpCategory.RecycleBin)]
+    [CmdletExample(
+        Code = @"PS:> Reset-PnpRecycleBinItems",
+        Remarks = "Restores all the items from the first and second stage recycle bin of the current context to their original locations",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Reset-PnpRecycleBinItems -Force",
+        Remarks = "Restores all the items from the first and second stage recycle bin of the current context to their original locations without asking for confirmation first",
+        SortOrder = 2)]
+    public class ResetPnpRecycleBinItems : SPOCmdlet
+    {
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to restore all the files from the first and second stage recycle bins to their original locations")]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (Force || ShouldContinue(Resources.ResetRecycleBinItems, Resources.Confirm))
+            {
+                ClientContext.Site.RecycleBin.RestoreAll();
+                ClientContext.ExecuteQueryRetry();
+            }                  
+        }
+    }
+}

--- a/Commands/RecycleBin/ResetTenantRecycleBinItem.cs
+++ b/Commands/RecycleBin/ResetTenantRecycleBinItem.cs
@@ -1,0 +1,51 @@
+﻿using System.Management.Automation;
+using System.Threading;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.RecycleBin
+{
+    [Cmdlet(VerbsCommon.Reset, "PnPTenantRecycleBinItem")]
+    [CmdletHelp("Restores a site collection from the tenant scoped recycle bin", 
+        DetailedDescription = @"The Reset-PnPTenantRecycleBinItem cmdlet allows a site collection that has been deleted and still exists in the tenant recycle bin to be restored to its original location.", 
+        Category = CmdletHelpCategory.TenantAdmin)]
+    [CmdletExample(
+        Code = @"PS:> Reset-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso",
+        Remarks = @"This will restore the deleted site collection with the url 'https://tenant.sharepoint.com/sites/contoso' to its original location", SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Reset-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso -Wait",
+        Remarks = @"This will restore the deleted site collection with the url 'https://tenant.sharepoint.com/sites/contoso' to its original location and will wait with executing further PowerShell commands until the site collection restore has completed", SortOrder = 2)]
+    public class ResetTenantRecycleBinItem : SPOAdminCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "Url of the site collection to restore from the tenant recycle bin", ValueFromPipeline = false)]
+        public string Url;
+
+        [Parameter(Mandatory = false, HelpMessage = "If provided, the PowerShell execution will halt until the site restore process has completed", ValueFromPipeline = false)]
+        public SwitchParameter Wait = false;
+
+        [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be asked to restore the site collection from the tenant recycle bin")]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (Force || ShouldContinue(string.Format(Resources.ResetTenantRecycleBinItem, Url), Resources.Confirm))
+            {
+                var spOperation = Tenant.RestoreDeletedSite(Url);
+                Tenant.Context.Load(spOperation);
+                Tenant.Context.ExecuteQueryRetry();
+
+                if (Wait)
+                {
+                    while (!spOperation.IsComplete)
+                    {
+                        Thread.Sleep(3000);
+                        Tenant.Context.Load(spOperation);
+                        Tenant.Context.ExecuteQueryRetry();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -359,6 +359,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Base\PipeBinds\RecycleBinItemPipeBind.cs" />
     <Compile Include="Graph\GetUnifiedGroup.cs" />
     <Compile Include="Admin\GetWebTemplates.cs" />
     <Compile Include="Admin\GetTimeZoneId.cs" />
@@ -493,10 +494,18 @@
     <Compile Include="Provider\SPODriveParameters.cs" />
     <Compile Include="Provider\SPOProvider.cs" />
     <Compile Include="Publishing\AddMasterPage.cs" />
+    <Compile Include="RecycleBin\ClearTenantRecycleBinItem.cs" />
+    <Compile Include="RecycleBin\ResetTenantRecycleBinItem.cs" />
+    <Compile Include="RecycleBin\ResetRecycleBinItem.cs" />
+    <Compile Include="RecycleBin\ClearRecycleBinItem.cs" />
     <Compile Include="Search\GetSiteSearchQueryResults.cs" />
     <Compile Include="Search\SetSearchConfiguration.cs" />
     <Compile Include="Search\GetSearchConfiguration.cs" />
+    <Compile Include="RecycleBin\ResetRecycleBinItems.cs" />
+    <Compile Include="RecycleBin\MoveRecycleBinItems.cs" />
     <Compile Include="Site\GetAuditing.cs" />
+    <Compile Include="RecycleBin\ClearRecycleBinItems.cs" />
+    <Compile Include="RecycleBin\GetRecycleBinItems.cs" />
     <Compile Include="Site\SetAuditing.cs" />
     <Compile Include="Taxonomy\RemoveTaxonomyItem.cs" />
     <Compile Include="Taxonomy\RemoveTermGroup.cs" />

--- a/Documentation/ClearPnPTenantRecycleBinItem.md
+++ b/Documentation/ClearPnPTenantRecycleBinItem.md
@@ -1,0 +1,32 @@
+#Clear-PnPTenantRecycleBinItem
+Permanently deletes a site collection from the tenant scoped recycle bin
+##Syntax
+```powershell
+Clear-PnPTenantRecycleBinItem -Url <String>
+                              [-Wait [<SwitchParameter>]]
+                              [-Force [<SwitchParameter>]]
+```
+
+
+##Detailed Description
+The Clear-PnPTenantRecycleBinItem cmdlet allows a site collection that has been deleted and still exists in the tenant recycle bin to be permanently deleted from the recycle bin as well.
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to permanently delete the site collection from the tenant recycle bin|
+|Url|String|True|Url of the site collection to permanently delete from the tenant recycle bin|
+|Wait|SwitchParameter|False|If provided, the PowerShell execution will halt until the operation has completed|
+##Examples
+
+###Example 1
+```powershell
+PS:> Clear-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso
+```
+This will permanently delete site collection with the url 'https://tenant.sharepoint.com/sites/contoso' from the tenant recycle bin
+
+###Example 2
+```powershell
+PS:> Clear-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso -Wait
+```
+This will permanently delete site collection with the url 'https://tenant.sharepoint.com/sites/contoso' from the tenant recycle bin and will wait with executing further PowerShell commands until the operation has completed

--- a/Documentation/ClearPnpRecycleBinItem.md
+++ b/Documentation/ClearPnpRecycleBinItem.md
@@ -1,0 +1,33 @@
+#Clear-PnpRecycleBinItem
+Permanently deletes the provided recycle bin item
+##Syntax
+```powershell
+Clear-PnpRecycleBinItem [-Force [<SwitchParameter>]]
+                        -Identity <RecycleBinItemPipeBind>
+```
+
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to permanently delete the recycle bin item|
+|Identity|RecycleBinItemPipeBind|True|Id of the recycle bin item or the recycle bin item itself to permanently delete|
+##Examples
+
+###Example 1
+```powershell
+PS:> Get-PnPRecycleBinItems | ? FileLeafName -like "*.docx" | Clear-PnpRecycleBinItem
+```
+Permanently deletes all the items in the first and second stage recycle bins of which the file names have the .docx extension
+
+###Example 2
+```powershell
+PS:> Clear-PnpRecycleBinItem -Identity 72e4d749-d750-4989-b727-523d6726e442
+```
+Permanently deletes the recycle bin item with Id 72e4d749-d750-4989-b727-523d6726e442 from the recycle bin
+
+###Example 3
+```powershell
+PS:> Clear-PnpRecycleBinItem -Identity $item -Force
+```
+Permanently deletes the recycle bin item stored under variable $item from the recycle bin without asking for confirmation from the end user first

--- a/Documentation/ClearPnpRecycleBinItems.md
+++ b/Documentation/ClearPnpRecycleBinItems.md
@@ -1,0 +1,33 @@
+#Clear-PnpRecycleBinItems
+Permanently deletes all the items in the recycle bins from the context
+##Syntax
+```powershell
+Clear-PnpRecycleBinItems [-SecondStageOnly [<SwitchParameter>]]
+                         [-Force [<SwitchParameter>]]
+```
+
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to clear the recycle bin|
+|SecondStageOnly|SwitchParameter|False|If provided, only all the items in the second stage recycle bin will be cleared|
+##Examples
+
+###Example 1
+```powershell
+PS:> Clear-PnpRecycleBinItems
+```
+Permanently deletes all the items in the first and second stage recycle bins from the context
+
+###Example 2
+```powershell
+PS:> Clear-PnpRecycleBinItems -SecondStageOnly
+```
+Permanently deletes all the items only in the second stage recycle bin from the context
+
+###Example 3
+```powershell
+PS:> Clear-PnpRecycleBinItems -Force
+```
+Permanently deletes all the items in the first and second stage recycle bins from the context without asking for confirmation from the end user first

--- a/Documentation/GetPnPRecycleBinItems.md
+++ b/Documentation/GetPnPRecycleBinItems.md
@@ -1,0 +1,28 @@
+#Get-PnPRecycleBinItems
+Returns the items in the recycle bin from the context
+##Syntax
+##Returns
+>[Microsoft.SharePoint.Client.RecycleBinItem](https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.recyclebinitem.aspx)
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+##Examples
+
+###Example 1
+```powershell
+PS:> Get-PnPRecycleBinItems
+```
+Returns all items in both the first and the second stage recycle bins in the current site collection
+
+###Example 2
+```powershell
+PS:> Get-PnPRecycleBinItems | ? ItemState -eq "FirstStageRecycleBin"
+```
+Returns all items in only the first stage recycle bin in the current site collection
+
+###Example 3
+```powershell
+PS:> Get-PnPRecycleBinItems | ? ItemState -eq "SecondStageRecycleBin"
+```
+Returns all items in only the second stage recycle bin in the current site collection

--- a/Documentation/MovePnpRecycleBinItems.md
+++ b/Documentation/MovePnpRecycleBinItems.md
@@ -1,0 +1,25 @@
+#Move-PnpRecycleBinItems
+Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin
+##Syntax
+```powershell
+Move-PnpRecycleBinItems [-Force [<SwitchParameter>]]
+```
+
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to move the first stage recycle bin items to the second stage|
+##Examples
+
+###Example 1
+```powershell
+PS:> Move-PnpRecycleBinItems
+```
+Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin
+
+###Example 2
+```powershell
+PS:> Move-PnpRecycleBinItems -Force
+```
+Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin without asking for confirmation first

--- a/Documentation/ResetPnPTenantRecycleBinItem.md
+++ b/Documentation/ResetPnPTenantRecycleBinItem.md
@@ -1,0 +1,32 @@
+#Reset-PnPTenantRecycleBinItem
+Restores a site collection from the tenant scoped recycle bin
+##Syntax
+```powershell
+Reset-PnPTenantRecycleBinItem -Url <String>
+                              [-Wait [<SwitchParameter>]]
+                              [-Force [<SwitchParameter>]]
+```
+
+
+##Detailed Description
+The Reset-PnPTenantRecycleBinItem cmdlet allows a site collection that has been deleted and still exists in the tenant recycle bin to be restored to its original location.
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to restore the site collection from the tenant recycle bin|
+|Url|String|True|Url of the site collection to restore from the tenant recycle bin|
+|Wait|SwitchParameter|False|If provided, the PowerShell execution will halt until the site restore process has completed|
+##Examples
+
+###Example 1
+```powershell
+PS:> Reset-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso
+```
+This will restore the deleted site collection with the url 'https://tenant.sharepoint.com/sites/contoso' to its original location
+
+###Example 2
+```powershell
+PS:> Reset-PnPTenantRecycleBinItem -Url https://tenant.sharepoint.com/sites/contoso -Wait
+```
+This will restore the deleted site collection with the url 'https://tenant.sharepoint.com/sites/contoso' to its original location and will wait with executing further PowerShell commands until the site collection restore has completed

--- a/Documentation/ResetPnpRecycleBinItem.md
+++ b/Documentation/ResetPnpRecycleBinItem.md
@@ -1,0 +1,27 @@
+#Reset-PnpRecycleBinItem
+Restores the provided recycle bin item to its original location
+##Syntax
+```powershell
+Reset-PnpRecycleBinItem [-Force [<SwitchParameter>]]
+                        -Identity <RecycleBinItemPipeBind>
+```
+
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to restore the recycle bin item|
+|Identity|RecycleBinItemPipeBind|True|Id of the recycle bin item or the recycle bin item itself to restore|
+##Examples
+
+###Example 1
+```powershell
+PS:> Get-PnPRecycleBinItems | ? FileLeafName -like "*.docx" | Reset-PnpRecycleBinItem
+```
+Restores all the items in the first and second stage recycle bins to their original location of which the filename ends with the .docx extension
+
+###Example 2
+```powershell
+PS:> Reset-PnpRecycleBinItem -Identity 72e4d749-d750-4989-b727-523d6726e442
+```
+Restores the recycle bin item with Id 72e4d749-d750-4989-b727-523d6726e442 to its original location

--- a/Documentation/ResetPnpRecycleBinItems.md
+++ b/Documentation/ResetPnpRecycleBinItems.md
@@ -1,0 +1,25 @@
+#Reset-PnpRecycleBinItems
+Restores all the items from the first and second stage recycle bin of the current context to their original locations
+##Syntax
+```powershell
+Reset-PnpRecycleBinItems [-Force [<SwitchParameter>]]
+```
+
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|Force|SwitchParameter|False|If provided, no confirmation will be asked to restore all the files from the first and second stage recycle bins to their original locations|
+##Examples
+
+###Example 1
+```powershell
+PS:> Reset-PnpRecycleBinItems
+```
+Restores all the items from the first and second stage recycle bin of the current context to their original locations
+
+###Example 2
+```powershell
+PS:> Reset-PnpRecycleBinItems -Force
+```
+Restores all the items from the first and second stage recycle bin of the current context to their original locations without asking for confirmation first

--- a/Documentation/readme.md
+++ b/Documentation/readme.md
@@ -5,6 +5,15 @@ Below you can find a list of all the available cmdlets. Many commands provide bu
 Get-Help Connect-PnPOnline -Detailed
 ```
 
+##
+Cmdlet|Description
+:-----|:----------
+**[Reset&#8209;PnpRecycleBinItem](ResetPnpRecycleBinItem.md)** |Restores the provided recycle bin item to its original location
+**[Clear&#8209;PnpRecycleBinItem](ClearPnpRecycleBinItem.md)** |Permanently deletes the provided recycle bin item
+**[Reset&#8209;PnpRecycleBinItems](ResetPnpRecycleBinItems.md)** |Restores all the items from the first and second stage recycle bin of the current context to their original locations
+**[Move&#8209;PnpRecycleBinItems](MovePnpRecycleBinItems.md)** |Moves all the items in the first stage recycle bin of the current context to the second stage recycle bin
+**[Clear&#8209;PnpRecycleBinItems](ClearPnpRecycleBinItems.md)** |Permanently deletes all the items in the recycle bins from the context
+**[Get&#8209;PnPRecycleBinItems](GetPnPRecycleBinItems.md)** |Returns the items in the recycle bin from the context
 ##Apps
 Cmdlet|Description
 :-----|:----------
@@ -190,6 +199,8 @@ Cmdlet|Description
 Cmdlet|Description
 :-----|:----------
 **[Get&#8209;PnPAccessToken](GetPnPAccessToken.md)** |Gets the OAuth 2.0 Access Token to consume the Microsoft Graph API
+**[Clear&#8209;PnPTenantRecycleBinItem](ClearPnPTenantRecycleBinItem.md)** |Permanently deletes a site collection from the tenant scoped recycle bin
+**[Reset&#8209;PnPTenantRecycleBinItem](ResetPnPTenantRecycleBinItem.md)** |Restores a site collection from the tenant scoped recycle bin
 **[Set&#8209;PnPTenantSite](SetPnPTenantSite.md)** |Office365 only: Uses the tenant API to set site information.
 **[Get&#8209;PnPTenantSite](GetPnPTenantSite.md)** |Office365 only: Uses the tenant API to retrieve site information.
 **[Remove&#8209;PnPTenantSite](RemovePnPTenantSite.md)** |Office365 only: Removes a site collection from the current tenant
@@ -212,12 +223,8 @@ Cmdlet|Description
 Cmdlet|Description
 :-----|:----------
 **[New&#8209;PnPPersonalSite](NewPnPPersonalSite.md)** |Office365 only: Creates a personal / OneDrive For Business site
-**[Set&#8209;PnPUserProfileProperty](SetPnPUserProfileProperty.md)** |Office365 only: Uses the tenant API to retrieve site information.
-
-You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this command. 
-
-**[Get&#8209;PnPUserProfileProperty](GetPnPUserProfileProperty.md)** |You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this cmdlet. 
-
+**[Set&#8209;PnPUserProfileProperty](SetPnPUserProfileProperty.md)** |Office365 only: Uses the tenant API to retrieve site information.  You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this command.  
+**[Get&#8209;PnPUserProfileProperty](GetPnPUserProfileProperty.md)** |You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this cmdlet.  
 ##Utilities
 Cmdlet|Description
 :-----|:----------

--- a/HelpAttributes/CmdletHelpCategory.cs
+++ b/HelpAttributes/CmdletHelpCategory.cs
@@ -38,6 +38,8 @@ namespace SharePointPnP.PowerShell.CmdletHelpAttributes
         [EnumMember(Value = "Files and Folders")]
         Files = 22,
         [EnumMember(Value = "Microsoft Graph")]
-        Graph = 23
+        Graph = 23,
+        [EnumMember(Value = "SharePoint Recycle Bin")]
+        RecycleBin = 24
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
The following new commands have been added to work with the SharePoint recycle bin:

- Clear-PnPRecycleBinItem
- Clear-PnPRecycleBinItems
- Clear-PnPTenantRecycleBinItem
- Get-PnPRecycleBinItems
- Move-PnPRecyclyBinItems
- Reset-PnPRecycleBinItem
- Reset-PnPRecycleBinItems
- Reset-PnPTenantRecycleBinItem

### Guidance ###
- Clear-PnPRecycleBinItem: Allows permanent deletion of specific item(s) from the site collection recycle bin
- Clear-PnPRecycleBinItems: Allows permanent deletion of all items from the site collection recycle bin
- Clear-PnPTenantRecycleBinItem: Allows permanent deletion of a site collection from the tenant recycle bin
- Get-PnPRecycleBinItems: Allows retrieving of all items currently in the first- and second stage site collection recycle bin
- Move-PnPRecyclyBinItems: Allows moving all items currently in the first stage site collection recycle bin to the second stage site collection recycle bin
- Reset-PnPRecycleBinItem: Allows restoring specific item(s) from either the first- and/or second stage recycle bins to their original locations
- Reset-PnPRecycleBinItems: Allows restoring of all items from both the first- and second stage recycle bins to their original locations
- Reset-PnPTenantRecycleBinItem: Allows restoring of a site collection from the tenant recycle bin to its original location