### PR TITLE
Fixed incorrect pointers to OfficeDevPnP Core library and psd1 file

### DIFF
--- a/Documentation/readme.md
+++ b/Documentation/readme.md
@@ -212,12 +212,8 @@ Cmdlet|Description
 Cmdlet|Description
 :-----|:----------
 **[New&#8209;PnPPersonalSite](NewPnPPersonalSite.md)** |Office365 only: Creates a personal / OneDrive For Business site
-**[Set&#8209;PnPUserProfileProperty](SetPnPUserProfileProperty.md)** |Office365 only: Uses the tenant API to retrieve site information.
-
-You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this command. 
-
-**[Get&#8209;PnPUserProfileProperty](GetPnPUserProfileProperty.md)** |You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this cmdlet. 
-
+**[Set&#8209;PnPUserProfileProperty](SetPnPUserProfileProperty.md)** |Office365 only: Uses the tenant API to retrieve site information.  You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this command.  
+**[Get&#8209;PnPUserProfileProperty](GetPnPUserProfileProperty.md)** |You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this cmdlet.  
 ##Utilities
 Cmdlet|Description
 :-----|:----------

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -86,10 +86,10 @@
       <Component Id="PowerShellCommands" Guid="{1F5CA574-E185-49D2-9A91-CD46A8548D3E}">
         <File Id="Commands" Source="$(var.SharePointPnP.PowerShell.Commands.TargetPath)" />
         <File Id="CommandsHelp" Source="$(var.SharePointPnP.PowerShell.Commands.TargetPath)-help.xml"/>
-        <File Id="Core" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\OfficePnP.Core.dll"/>
+        <File Id="Core" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\OfficeDevPnP.Core.dll"/>
         <File Id="CmdletHelpAttributes" Source="$(var.SharePointPnP.PowerShell.CmdletHelpAttributes.TargetPath)"/>
         <File Id="FormatFile" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\ModuleFiles\$(var.ProductAssemblyName).Format.ps1xml" />
-        <File Id="PSD1File" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\ModuleFiles\$(var.ProductAssemblyName).psd1" />
+        <File Id="PSD1File" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\ModuleFiles\SharePointPnPPowerShellOnline.psd1" />
         <File Id="ClientSDK.Client" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\Microsoft.SharePoint.Client.dll" />
         <File Id="ClientSDK.Client.Runtime" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\Microsoft.SharePoint.Client.Runtime.dll" />
         <File Id="ClientSDK.Client.Taxonomy" Source="$(var.SharePointPnP.PowerShell.Commands.ProjectDir)bin\$(var.SharePointPnP.PowerShell.Commands.Configuration)\Microsoft.SharePoint.Client.Taxonomy.dll" />


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
The Wix setup project wouldn't build for me in Visual Studio. It had two build time errors on finding the core dll and the psd1, which both had a different filename. Not sure if it's just me or it's indeed broken for everyone. Please verify before merging.

## What is in this Pull Request ? ##
Fix for the Wix builder
