### PR TITLE
The List parameter should be mandatory, as mentioned in #616

### DIFF
--- a/Commands/Lists/SetDefaultColumnValues.cs
+++ b/Commands/Lists/SetDefaultColumnValues.cs
@@ -27,7 +27,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Remarks = "Sets a default value for the MyTextField text field on a library to a value of \"DefaultValue\"")]
     public class SetDefaultColumnValues : SPOWebCmdlet
     {
-        [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Name or Url of the list.")]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Name or Url of the list.")]
         public ListPipeBind List;
 
         [Parameter(Mandatory = true, HelpMessage = "The internal name, id or a reference to a field")]


### PR DESCRIPTION
## Type ##
- [ x] Bug Fix

## Related Issues? ##
Fixes #616 

## What is in this Pull Request ? ##
As described in #616, the list parameter should always be provided. The cmdlet only makes sense with a given list, thus the parameter has been made mandatory