### PR TITLE
Adding Folder option to Add-PnpPublishingPage Cmdlet

### DIFF
--- a/Commands/Publishing/AddPublishingPage.cs
+++ b/Commands/Publishing/AddPublishingPage.cs
@@ -18,6 +18,10 @@ namespace SharePointPnP.PowerShell.Commands.Publishing
         [Alias("Name")]
         public string PageName = string.Empty;
 
+        [Parameter(Mandatory = true, HelpMessage = "The site relative folder path of the page to be added")]
+        [Alias("Folder")]
+        public string FolderPath = string.Empty;
+
         [Parameter(Mandatory = true, HelpMessage = "The name of the page layout you want to use. Specify without the .aspx extension. So 'ArticleLeft' or 'BlankWebPartPage'")]
         public string PageTemplateName = null;
 
@@ -29,16 +33,22 @@ namespace SharePointPnP.PowerShell.Commands.Publishing
 
         protected override void ExecuteCmdlet()
         {
+            Folder pageFolder = null;
+            if(!string.IsNullOrEmpty(FolderPath))
+            {
+                pageFolder = SelectedWeb.EnsureFolderPath(FolderPath);
+            }
+
             switch (ParameterSetName)
             {
                 case "WithTitle":
                     {
-                        SelectedWeb.AddPublishingPage(PageName, PageTemplateName, Title, publish: Publish);
+                        SelectedWeb.AddPublishingPage(PageName, PageTemplateName, Title, publish: Publish, folder: pageFolder);
                         break;
                     }
                 default:
                     {
-                        SelectedWeb.AddPublishingPage(PageName, PageTemplateName, publish: Publish);
+                        SelectedWeb.AddPublishingPage(PageName, PageTemplateName, publish: Publish, folder: pageFolder);
                         break;
                     }
             }

--- a/Commands/Publishing/AddPublishingPage.cs
+++ b/Commands/Publishing/AddPublishingPage.cs
@@ -12,6 +12,11 @@ namespace SharePointPnP.PowerShell.Commands.Publishing
         Code = @"PS:> Add-PnPPublishingPage -PageName 'OurNewPage' -Title 'Our new page' -PageTemplateName 'ArticleLeft'",
         Remarks = "Creates a new page based on the pagelayout 'ArticleLeft'",
         SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPPublishingPage -PageName 'OurNewPage' -Title 'Our new page' -PageTemplateName 'ArticleLeft' -Folder '/Pages/folder'",
+        Remarks = "Creates a new page based on the pagelayout 'ArticleLeft' with a site relative folder path",
+        SortOrder = 2)]
+
     public class AddPublishingPage : SPOWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "The name of the page to be added as an aspx file")]


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
This pull request will add a -Folder parameter to the Add-PnPPublishingPage Cmdlet so that publishing pages can be created inside of folders from powershell. This functionality already exists in the OfficeDevPnP.Core project, but is not surfaced by this Cmdlet.

