### PR TITLE
Fix for #593

### DIFF
--- a/Commands/Lists/AddListItem.cs
+++ b/Commands/Lists/AddListItem.cs
@@ -159,6 +159,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                                                 item[key as string] = new FieldUserValue() { LookupId = userId };
                                             }
                                         }
+                                        item.Update();
                                         break;
                                     }
                                 default:


### PR DESCRIPTION
## Type ##
- [x ] Bug Fix

## Related Issues? ##
Fixes #593 

## What is in this Pull Request ? ##
Added a item.Update() call after a User field is added. Without this, it is not possible to populate multiple User fields.
For example, before the fix, the following call would only add Person2, but not Person1 and Person3:
Add-PnPListItem -List "Sales Pipeline" -Values @{"Person1" = "user1@contoso.com"; "Person2"="user2@contoso.com"; "Person3"="user3@contoso.com"; "Title" = "Test"}
