### PR TITLE
Refactored Get-PnPFile

### DIFF
--- a/Commands/Files/GetFile.cs
+++ b/Commands/Files/GetFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.Core.Utilities;
@@ -6,73 +7,69 @@ using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
 
 namespace SharePointPnP.PowerShell.Commands.Files
 {
-    [Cmdlet(VerbsCommon.Get, "PnPFile")]
+    [Cmdlet(VerbsCommon.Get, "PnPFile", DefaultParameterSetName = "URLASFILEOBJECT")]
     [CmdletAlias("Get-SPOFile")]
     [CmdletHelp("Downloads a file.",
         Category = CmdletHelpCategory.Files,
         OutputType = typeof(File),
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.file.aspx")]
     [CmdletExample(
-        Code = @"PS:> Get-PnPFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor",
+        Code = @"PS:> Get-PnPFile -Url /sites/project/_catalogs/themes/15/company.spcolor",
         Remarks = "Retrieves the file and downloads it to the current folder",
         SortOrder = 1)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
+        Code = @"PS:> Get-PnPFile -Url /sites/project/_catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
         Remarks = "Retrieves the file and downloads it to c:\\temp\\company.spcolor",
         SortOrder = 2)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsString",
+        Code = @"PS:> Get-PnPFile -Url /sites/project/_catalogs/themes/15/company.spcolor -AsString",
         Remarks = "Retrieves the file and outputs its contents to the console",
         SortOrder = 3)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsFile",
+        Code = @"PS:> Get-PnPFile -Url /sites/project/_catalogs/themes/15/company.spcolor -AsFile",
         Remarks = "Retrieves the file and returns it as a File object",
         SortOrder = 4)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsListItem",
+        Code = @"PS:> Get-PnPFile -Url /sites/project/_catalogs/themes/15/company.spcolor -AsListItem",
         Remarks = "Retrieves the file and returns it as a ListItem object",
         SortOrder = 5)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
+        Code = @"PS:> Get-PnPFile -Url _catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
         Remarks = "Retrieves the file by site relative URL and downloads it to c:\\temp\\company.spcolor",
         SortOrder = 6)]
 
     public class GetFile : SPOWebCmdlet
     {
-        [Parameter(Mandatory = true, ParameterSetName = "SERVER", Position = 0, ValueFromPipeline = true, HelpMessage = "Server relative URL to the file")]
-        [Parameter(Mandatory = true, ParameterSetName = "ServerAsString", Position = 0, ValueFromPipeline = true, HelpMessage = "Server relative URL to the file")]
-        [Parameter(Mandatory = true, ParameterSetName = "ServerAsFile", Position = 0, ValueFromPipeline = true, HelpMessage = "Server relative URL to the file")]
-        [Parameter(Mandatory = true, ParameterSetName = "ServerAsListItem", Position = 0, ValueFromPipeline = true, HelpMessage = "Server relative URL to the file")]
-        public string ServerRelativeUrl = string.Empty;
+        private const string URLTOPATH = "URLTOPATH";
+        private const string URLASSTRING = "URLASSTRING";
+        private const string URLASLISTITEM = "URLASLISTITEM";
+        private const string URLASFILEOBJECT = "URLASFILEOBJECT";
 
-        [Parameter(Mandatory = true, ParameterSetName = "SITE", Position = 0, ValueFromPipeline = true, HelpMessage = "Site relative URL to the file")]
-        [Parameter(Mandatory = true, ParameterSetName = "SiteAsString", Position = 0, ValueFromPipeline = true, HelpMessage = "Site relative URL to the file")]
-        [Parameter(Mandatory = true, ParameterSetName = "SiteAsFile", Position = 0, ValueFromPipeline = true, HelpMessage = "Site relative URL to the file")]
-        [Parameter(Mandatory = true, ParameterSetName = "SiteAsListItem", Position = 0, ValueFromPipeline = true, HelpMessage = "Site relative URL to the file")]
-        public string SiteRelativeUrl = string.Empty;
+        [Parameter(Mandatory = true, ParameterSetName = URLASFILEOBJECT, HelpMessage = "The URL (server or site relative) to the file", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = URLASLISTITEM, HelpMessage = "The URL (server or site relative) to the file", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = URLTOPATH, HelpMessage = "The URL (server or site relative) to the file", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = URLASSTRING, HelpMessage = "The URL (server or site relative) to the file", Position = 0, ValueFromPipeline = true)]
+        [Alias(new[] { "ServerRelativeUrl", "SiteRelativeUrl" })]
+        public string Url;
 
-        [Parameter(Mandatory = false, ParameterSetName = "SERVER", HelpMessage = "Local path where the file should be saved")]
-        [Parameter(Mandatory = false, ParameterSetName = "SITE", HelpMessage = "Local path where the file should be saved")]
+        [Parameter(Mandatory = false, ParameterSetName = URLTOPATH, HelpMessage = "Local path where the file should be saved")]
         public string Path = string.Empty;
 
-        [Parameter(Mandatory = false, ParameterSetName = "SERVER", HelpMessage = "Name for the local file")]
-        [Parameter(Mandatory = false, ParameterSetName = "SITE", HelpMessage = "Name for the local file")]
+        [Parameter(Mandatory = false, ParameterSetName = URLTOPATH, HelpMessage = "Name for the local file")]
         public string Filename = string.Empty;
 
-        [Parameter(Mandatory = false, ParameterSetName = "ServerAsFile")]
-        [Parameter(Mandatory = false, ParameterSetName = "SiteAsFile")]
+        [Parameter(Mandatory = true, ParameterSetName = URLTOPATH)]
         public SwitchParameter AsFile;
 
-        [Parameter(Mandatory = false, ParameterSetName = "ServerAsListItem")]
-        [Parameter(Mandatory = false, ParameterSetName = "SiteAsListItem")]
+        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM)]
         public SwitchParameter AsListItem;
 
-        [Parameter(Mandatory = false, ParameterSetName = "ServerAsString", HelpMessage = "Retrieve the file contents as a string")]
-        [Parameter(Mandatory = false, ParameterSetName = "SiteAsString", HelpMessage = "Retrieve the file contents as a string")]
+        [Parameter(Mandatory = false, ParameterSetName = URLASSTRING, HelpMessage = "Retrieve the file contents as a string")]
         public SwitchParameter AsString;
 
         protected override void ExecuteCmdlet()
         {
+            var serverRelativeUrl = "";
             if (string.IsNullOrEmpty(Path))
             {
                 Path = SessionState.Path.CurrentFileSystemLocation.Path;
@@ -85,23 +82,26 @@ namespace SharePointPnP.PowerShell.Commands.Files
                 }
             }
 
-            if (MyInvocation.BoundParameters.ContainsKey("SiteRelativeUrl"))
+            var webUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+
+            if (!Url.ToLower().StartsWith(webUrl.ToLower()))
             {
-                var webUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
-                ServerRelativeUrl = UrlUtility.Combine(webUrl, SiteRelativeUrl);
+                serverRelativeUrl = UrlUtility.Combine(webUrl, Url);
+            }
+            else
+            {
+                serverRelativeUrl = Url;
             }
 
             File file = null;
 
             switch (ParameterSetName)
             {
-                case "SERVER":
-                case "SITE":
-                    SelectedWeb.SaveFileToLocal(ServerRelativeUrl, Path, Filename);
+                case URLTOPATH:
+                    SelectedWeb.SaveFileToLocal(serverRelativeUrl, Path, Filename);
                     break;
-                case "ServerAsFile":
-                case "SiteAsFile":
-                    file = SelectedWeb.GetFileByServerRelativeUrl(ServerRelativeUrl);
+                case URLASFILEOBJECT:
+                    file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
 
                     ClientContext.Load(file, f => f.Author, f => f.Length,
                         f => f.ModifiedBy, f => f.Name, f => f.TimeCreated,
@@ -111,10 +111,8 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
                     WriteObject(file);
                     break;
-
-                case "ServerAsListItem":
-                case "SiteAsListItem":
-                    file = SelectedWeb.GetFileByServerRelativeUrl(ServerRelativeUrl);
+                case URLASLISTITEM:
+                    file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
 
                     ClientContext.Load(file, f => f.Exists, f => f.ListItemAllFields);
 
@@ -124,10 +122,8 @@ namespace SharePointPnP.PowerShell.Commands.Files
                         WriteObject(file.ListItemAllFields);
                     }
                     break;
-
-                case "ServerAsString":
-                case "SiteAsString":
-                    WriteObject(SelectedWeb.GetFileAsString(ServerRelativeUrl));
+                case URLASSTRING:
+                    WriteObject(SelectedWeb.GetFileAsString(serverRelativeUrl));
                     break;
             }
         }

--- a/Documentation/GetPnPFile.md
+++ b/Documentation/GetPnPFile.md
@@ -2,60 +2,31 @@
 Downloads a file.
 ##Syntax
 ```powershell
-Get-PnPFile [-Path <String>]
-            [-Filename <String>]
-            [-Web <WebPipeBind>]
-            -ServerRelativeUrl <String>
-```
-
-
-```powershell
-Get-PnPFile [-AsFile [<SwitchParameter>]]
-            [-Web <WebPipeBind>]
-            -ServerRelativeUrl <String>
+Get-PnPFile [-Web <WebPipeBind>]
+            -Url <String>
 ```
 
 
 ```powershell
 Get-PnPFile [-AsListItem [<SwitchParameter>]]
             [-Web <WebPipeBind>]
-            -ServerRelativeUrl <String>
+            -Url <String>
 ```
 
 
 ```powershell
 Get-PnPFile [-AsString [<SwitchParameter>]]
             [-Web <WebPipeBind>]
-            -ServerRelativeUrl <String>
+            -Url <String>
 ```
 
 
 ```powershell
 Get-PnPFile [-Path <String>]
             [-Filename <String>]
+            -AsFile [<SwitchParameter>]
             [-Web <WebPipeBind>]
-            -SiteRelativeUrl <String>
-```
-
-
-```powershell
-Get-PnPFile [-AsFile [<SwitchParameter>]]
-            [-Web <WebPipeBind>]
-            -SiteRelativeUrl <String>
-```
-
-
-```powershell
-Get-PnPFile [-AsListItem [<SwitchParameter>]]
-            [-Web <WebPipeBind>]
-            -SiteRelativeUrl <String>
-```
-
-
-```powershell
-Get-PnPFile [-AsString [<SwitchParameter>]]
-            [-Web <WebPipeBind>]
-            -SiteRelativeUrl <String>
+            -Url <String>
 ```
 
 
@@ -65,13 +36,12 @@ Get-PnPFile [-AsString [<SwitchParameter>]]
 ##Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
-|AsFile|SwitchParameter|False||
+|AsFile|SwitchParameter|True||
 |AsListItem|SwitchParameter|False||
 |AsString|SwitchParameter|False|Retrieve the file contents as a string|
 |Filename|String|False|Name for the local file|
 |Path|String|False|Local path where the file should be saved|
-|ServerRelativeUrl|String|True|Server relative URL to the file|
-|SiteRelativeUrl|String|True|Site relative URL to the file|
+|Url|String|True|The URL (server or site relative) to the file|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ##Examples
 

--- a/Documentation/GetPnPPublishingImageRendition.md
+++ b/Documentation/GetPnPPublishingImageRendition.md
@@ -2,15 +2,18 @@
 Returns all image renditions or if Identity is specified a specific one
 ##Syntax
 ```powershell
-Get-PnPPublishingImageRendition [-Identity <ImageRenditionPipeBind>]
-                                [-Web <WebPipeBind>]
+Get-PnPPublishingImageRendition [-Web <WebPipeBind>]
+                                [-Identity <ImageRenditionPipeBind>]
 ```
 
+
+##Returns
+>[Microsoft.SharePoint.Client.Publishing.ImageRendition](https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.publishing.imagerendition.aspx)
 
 ##Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
-|Identity|ImageRenditionPipeBind|False||
+|Identity|ImageRenditionPipeBind|False|Id or name of an existing image rendition|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ##Examples
 

--- a/Documentation/RemovePnPPublishingImageRendition.md
+++ b/Documentation/RemovePnPPublishingImageRendition.md
@@ -12,7 +12,7 @@ Remove-PnPPublishingImageRendition [-Force [<SwitchParameter>]]
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
 |Force|SwitchParameter|False|If provided, no confirmation will be asked to remove the Image Rendition.|
-|Identity|ImageRenditionPipeBind|True|The display name of the Image Rendition.|
+|Identity|ImageRenditionPipeBind|True|The display name or id of the Image Rendition.|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ##Examples
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Added Clear-PnPRecyclyBinItem, Clear-PnPTenantRecyclyBinItem, Get-PnPRecyclyBinItem, Move-PnPRecyclyBinItem, Restore-PnPRecyclyBinItem, Restore-PnPTenantRecyclyBinItem cmdlets
 * Added Move-PnPFolder, Rename-PnPFolder cmdlets
 * Added Add-PnPPublishingImageRendition, Get-PnPPublishingImageRendition and Remove-PnPPublishingImageRendition cmdlets
+* Refactored Get-PnPFile. ServerRelativeUrl and SiteRelativeUrl are now obsolete (but will still work), use the Url parameter instead which takes either a server or site relative url.
 
 **2016-11-21**
 * Added support to enable versionining and set the maximum number of versions to keep on a list and library with Set-PnPList


### PR DESCRIPTION
the ServerRelativeUrl and SiteRelativeUrl parameters are now obsolete (but will still work) and one should now use -Url. The Url parameter accepts both server and site relative urls.