### PR TITLE
Pnp web retrieval cmdlet update with processing sub properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+/Commands/Base/Validation/DynamicTypeValidateSet.cs

--- a/.gitignore
+++ b/.gitignore
@@ -213,4 +213,3 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
-/Commands/Base/Validation/DynamicTypeValidateSet.cs

--- a/Commands/Lists/GetList.cs
+++ b/Commands/Lists/GetList.cs
@@ -35,12 +35,9 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         protected override void ExecuteCmdlet()
         {
 
-            AlwaysLoadProperties = new[] { "Id", "BaseTemplate", "OnQuickLaunch", "DefaultViewUrl", "Title", "Hidden" };
+            AlwaysLoadProperties = new[] { "Id", "BaseTemplate", "OnQuickLaunch", "DefaultViewUrl", "Title", "Hidden", "RootFolder.ServerRelativeUrl" };
 
             var expressions = Expressions.ToList();
-            Expression<Func<List, object>> expressionRelativeUrl = l => l.RootFolder.ServerRelativeUrl;
-
-            expressions.Add(expressionRelativeUrl);
 
             if (Identity != null)
             {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Updated the expression builder in PnPWebRetrievalCmdlet to enable developers using this Cmdlet type to include sub properties "RootFolder.ServerRelativeUrl" in the AlwaysLoadProperties. 

I didn't update the ValidationSet to include sub properties, cause where does it end, it could wind up recursive with ParentList and other elements.. 

I was hoping to find a way to provide auto complete of the direct properties in a ValidationSet then override the actual validation to enable sub properties, but I haven't figured that out yet..
