### PR TITLE
Re-worked PnP-Copy file to work for cross site/site collection

### DIFF
--- a/Commands/Files/CopyFile.cs
+++ b/Commands/Files/CopyFile.cs
@@ -11,51 +11,71 @@ using File = Microsoft.SharePoint.Client.File;
 
 namespace SharePointPnP.PowerShell.Commands.Files
 {
-    [Cmdlet(VerbsCommon.Copy, "PnPFile", SupportsShouldProcess = true)]
+    [Cmdlet(VerbsCommon.Copy, "PnPFile", SupportsShouldProcess = true, DefaultParameterSetName = "SOURCEURL")]
     [CmdletAlias("Copy-SPOFile")]
     [CmdletHelp("Copies a file or folder to a different location",
         Category = CmdletHelpCategory.Files)]
     [CmdletExample(
-        Remarks = "Copies a file named company.docx located in a document library called Documents in the projects sitecollection to the site collection otherproject. If a file named company.aspx already exists, it won't perform the copy.",
-        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx",
+        Remarks = "Copies a file named company.docx located in a document library called Documents in the current site to the site collection otherproject. If a file named company.docx already exists, it won't perform the copy.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx",
         SortOrder = 1)]
     [CmdletExample(
-        Remarks = "Copies a file named company.docx located in a document library called Documents in the current site to the Documents library in the site collection otherproject. If a file named company.aspx already exists, it won't perform the copy.",
-        Code = @"PS:>Copy-PnPFile -SiteRelativeUrl Documents/company.aspx -TargetUrl /sites/otherproject/Documents/company.docx",
+        Remarks = "Copies a file named company.docx located in a document library called Documents to a new document named company2.docx in the same library.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/company.docx -TargetUrl Documents/company2.docx",
         SortOrder = 2)]
     [CmdletExample(
-        Remarks = "Copies a file named company.docx located in a document library called Documents in the projects sitecollection to the site collection otherproject. If a file named company.aspx already exists, it will still perform the copy and replace the original company.aspx file.",
-        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx -OverwriteIfAlreadyExists",
+        Remarks = "Copies a file named company.docx located in a document library called Documents to a document library called Documents2 in the same site. ",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/company.docx -TargetUrl Documents2/company.docx",
         SortOrder = 3)]
     [CmdletExample(
-        Remarks = "Copies a folder named MyDocs in the document library called Documents located in the projects sitecollection to the site collection otherproject. If the MyDocs folder exist it will copy into it, if not it will be created.",
-        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/MyDocs -TargetUrl /sites/otherproject/Documents -OverwriteIfAlreadyExists",
+        Remarks = "Copies a file named company.docx located in a document library called Documents to the document library named Document in a subsite named Subsite as a new document named company2.docx.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/company.docx -TargetUrl Subsite/Documents/company2.docx",
         SortOrder = 4)]
     [CmdletExample(
-        Remarks = "Copies a folder named MyDocs in the document library called Documents located in the projects sitecollection to the root folder of the library named Documents in the site collection otherproject.",
-        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/MyDocs -TargetUrl /sites/otherproject/Documents -SkipSourceFolderName -OverwriteIfAlreadyExists",
+        Remarks = "Copies a file named company.docx located in a document library called Documents to the document library named Document in a subsite named Subsite keeping the file name.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/company.docx -TargetUrl Subsite/Documents",
         SortOrder = 5)]
     [CmdletExample(
-        Remarks = "Copies a folder named MyDocs in the MyDocs folder of the library named Documents. If the MyDocs folder does not exists, it will be created.",
-        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/MyDocs -TargetUrl /sites/otherproject/Documents/MyDocs -SkipSourceFolderName -OverwriteIfAlreadyExists",
+        Remarks = "Copies a file named company.docx located in a document library called Documents in the current site to the site collection otherproject. If a file named company.docx already exists, it will still perform the copy and replace the original company.docx file.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx -OverwriteIfAlreadyExists",
         SortOrder = 6)]
     [CmdletExample(
-        Remarks = "Copies a folder named MyDocs in the root of the library named Documents. If the MyDocs folder exists in the target, a subfolder also named MyDocs is created.",
-        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/MyDocs -TargetUrl /sites/otherproject/Documents/MyDocs -OverwriteIfAlreadyExists",
+        Remarks = "Copies a folder named MyDocs in the document library called Documents located in the current site to the site collection otherproject. If the MyDocs folder exist it will copy into it, if not it will be created.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/MyDocs -TargetUrl /sites/otherproject/Documents -OverwriteIfAlreadyExists",
         SortOrder = 7)]
+    [CmdletExample(
+        Remarks = "Copies a folder named MyDocs in the document library called Documents located in the current site to the root folder of the library named Documents in the site collection otherproject.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/MyDocs -TargetUrl /sites/otherproject/Documents -SkipSourceFolderName -OverwriteIfAlreadyExists",
+        SortOrder = 8)]
+    [CmdletExample(
+        Remarks = "Copies a folder named MyDocs in the MyDocs folder of the library named Documents. If the MyDocs folder does not exists, it will be created.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/MyDocs -TargetUrl /sites/otherproject/Documents/MyDocs -SkipSourceFolderName -OverwriteIfAlreadyExists",
+        SortOrder = 9)]
+    [CmdletExample(
+        Remarks = "Copies a folder named MyDocs in the root of the library named Documents. If the MyDocs folder exists in the target, a subfolder also named MyDocs is created.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl Documents/MyDocs -TargetUrl /sites/otherproject/Documents/MyDocs -OverwriteIfAlreadyExists",
+        SortOrder = 10)]
+    [CmdletExample(
+        Remarks = "Copies a file named company.docx in the library named Documents in SubSite1 to the library named Documents in SubSite2.",
+        Code = @"PS:>Copy-PnPFile -SourceUrl SubSite1/Documents/company.docx -TargetUrl SubSite2/Documents",
+        SortOrder = 10)]
 
     public class CopyFile : SPOWebCmdlet
     {
         private ProgressRecord _progressFolder = new ProgressRecord(0, "Activity", "Status") { Activity = "Copying folder" };
         private ProgressRecord _progressFile = new ProgressRecord(1, "Activity", "Status") { Activity = "Copying file" };
+        private ClientContext _sourceContext;
+        private ClientContext _targetContext;
 
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = "SERVER", HelpMessage = "Server relative Url specifying the file to move. Must include the file name.")]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = "SERVER", HelpMessage = "Server relative Url specifying the file or folder to copy.")]
+        [Obsolete("Use SourceUrl instead.")]
         public string ServerRelativeUrl = string.Empty;
 
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = "SITE", HelpMessage = "Site relative Url specifying the file to move. Must include the file name.")]
-        public string SiteRelativeUrl = string.Empty;
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = "SOURCEURL", HelpMessage = "Site relative Url specifying the file or folder to copy.")]
+        [Alias("SiteRelativeUrl")]
+        public string SourceUrl = string.Empty;
 
-        [Parameter(Mandatory = true, Position = 1, HelpMessage = "Server relative Url where to copy the file to. Must include the file name.")]
+        [Parameter(Mandatory = true, Position = 1, HelpMessage = "Server relative Url where to copy the file or folder to.")]
         public string TargetUrl = string.Empty;
 
         [Parameter(Mandatory = false, HelpMessage = "If provided, if a file already exists at the TargetUrl, it will be overwritten. If ommitted, the copy operation will be canceled if the file already exists at the TargetUrl location.")]
@@ -69,45 +89,58 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
-            if (ParameterSetName == "SITE")
+            var sourceServerRelativeUrl = SourceUrl ?? ServerRelativeUrl;
+            var webServerRelativeUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+            if (!string.IsNullOrEmpty(SourceUrl) && !SourceUrl.StartsWith(webServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
             {
-                var webUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
-                ServerRelativeUrl = UrlUtility.Combine(webUrl, SiteRelativeUrl);
+                sourceServerRelativeUrl = UrlUtility.Combine(webServerRelativeUrl, SourceUrl);
+            }
+            if (!TargetUrl.StartsWith("/"))
+            {
+                //site relative URL
+                TargetUrl = UrlUtility.Combine(webServerRelativeUrl, TargetUrl);
             }
 
-            var file = SelectedWeb.GetFileByServerRelativeUrl(ServerRelativeUrl);
-            var folder = SelectedWeb.GetFolderByServerRelativeUrl(ServerRelativeUrl);
-            ClientContext.Load(file, f => f.Name, f => f.Exists);
-            ClientContext.ExecuteQueryRetry();
-            ClientContext.Load(folder, f => f.Name, f => f.Exists);
-            ClientContext.ExecuteQueryRetry();
-            bool srcIsFolder = folder.Exists;
+            Uri currentContextUri = new Uri(ClientContext.Url);
 
-            if (Force || ShouldContinue(string.Format(Resources.CopyFile0To1, ServerRelativeUrl, TargetUrl), Resources.Confirm))
+            Uri sourceUri = new Uri(currentContextUri, sourceServerRelativeUrl);
+            Uri sourceWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, sourceUri);
+            Uri targetUri = new Uri(currentContextUri, TargetUrl);
+            Uri targetWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
+
+            _sourceContext = ClientContext;
+            if (!currentContextUri.AbsoluteUri.Equals(sourceWebUri.AbsoluteUri, StringComparison.InvariantCultureIgnoreCase))
             {
-                var srcWeb = ClientContext.Web;
-                ClientContext.Load(srcWeb, s => s.Url);
-                ClientContext.ExecuteQueryRetry();
+                _sourceContext = ClientContext.Clone(sourceWebUri);
+            }
 
-                Uri uri = new Uri(ClientContext.Url);
-                Uri targetUri = new Uri(uri, TargetUrl);
-                var webUrl = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
-                var targetContext = ClientContext.Clone(webUrl.AbsoluteUri);
-                var dstWeb = targetContext.Web;
-                targetContext.Load(dstWeb, s => s.Url);
-                targetContext.ExecuteQueryRetry();
+            File file = _sourceContext.Web.GetFileByServerRelativeUrl(sourceServerRelativeUrl);
+            Folder folder = _sourceContext.Web.GetFolderByServerRelativeUrl(sourceServerRelativeUrl);
+            file.EnsureProperties(f => f.Name, f => f.Exists);
+            folder.EnsureProperties(f => f.Name, f => f.Exists);
+            bool srcIsFolder = folder.Exists;
+            
+            if (Force || ShouldContinue(string.Format(Resources.CopyFile0To1, sourceServerRelativeUrl, TargetUrl), Resources.Confirm))
+            {
+                var srcWeb = _sourceContext.Web;
+                srcWeb.EnsureProperty(s => s.Url);
+
+                _targetContext = ClientContext.Clone(targetWebUri.AbsoluteUri);
+                var dstWeb = _targetContext.Web;
+                dstWeb.EnsureProperty(s => s.Url);
                 if (srcWeb.Url == dstWeb.Url)
                 {
                     try
                     {
                         // If src/dst are on the same Web, then try using CopyTo - backwards compability
                         file.CopyTo(TargetUrl, OverwriteIfAlreadyExists);
-                        ClientContext.ExecuteQueryRetry();
+                        _sourceContext.ExecuteQueryRetry();
                         return;
                     }
                     catch
                     {
-                        //swallow exception, in case target was a lib/folder
+                        SkipSourceFolderName = true; // target folder exist
+                        //swallow exception, in case target was a lib/folder which exists
                     }
                 }
 
@@ -117,18 +150,18 @@ namespace SharePointPnP.PowerShell.Commands.Files
                 bool targetFolderExists = false;
                 try
                 {
-                    targetFolder = targetContext.Web.GetFolderByServerRelativeUrl(TargetUrl);
-                    targetContext.Load(targetFolder, f => f.Name, f => f.Exists);
-                    targetContext.ExecuteQueryRetry();
+                    targetFolder = _targetContext.Web.GetFolderByServerRelativeUrl(TargetUrl);
+                    targetFolder.EnsureProperties(f => f.Name, f => f.Exists);
                     if (!targetFolder.Exists) throw new Exception("TargetUrl is an existing file, not folder");
                     targetFolderExists = true;
                 }
                 catch (Exception)
                 {
+                    targetFolder = null;
                     Expression<Func<List, object>> expressionRelativeUrl = l => l.RootFolder.ServerRelativeUrl;
-                    var query = targetContext.Web.Lists.IncludeWithDefaultProperties(expressionRelativeUrl);
-                    var lists = targetContext.LoadQuery(query);
-                    targetContext.ExecuteQueryRetry();
+                    var query = _targetContext.Web.Lists.IncludeWithDefaultProperties(expressionRelativeUrl);
+                    var lists = _targetContext.LoadQuery(query);
+                    _targetContext.ExecuteQueryRetry();
                     lists = lists.OrderByDescending(l => l.RootFolder.ServerRelativeUrl); // order descending in case more lists start with the same
                     foreach (List targetList in lists)
                     {
@@ -156,17 +189,13 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         private void CopyFolder(Folder sourceFolder, Folder targetFolder)
         {
-            ClientContext.Load(sourceFolder, folder => folder.Files, folder => folder.Folders, folder => folder.Files.Include(f => f.ServerRelativeUrl));
-            sourceFolder.EnsureProperty(f => f.ServerRelativeUrl);
-            ClientContext.ExecuteQueryRetry();
+            sourceFolder.EnsureProperties(f => f.ServerRelativeUrl, f => f.Files, f => f.Folders, folder => folder.Files.Include(f => f.ServerRelativeUrl));
             targetFolder.EnsureProperty(f => f.ServerRelativeUrl);
-            targetFolder.Context.ExecuteQueryRetry();
 
             _progressFolder.RecordType = ProgressRecordType.Processing;
             _progressFolder.StatusDescription = $"{sourceFolder.ServerRelativeUrl} to {targetFolder.ServerRelativeUrl}";
             _progressFolder.PercentComplete = 0;
             WriteProgress(_progressFolder);
-
 
             _progressFile.RecordType = ProgressRecordType.Processing;
             foreach (File file in sourceFolder.Files)
@@ -195,10 +224,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
         private void UploadFile(File srcFile, Folder targetFolder, string filename = "")
         {
             var binaryStream = srcFile.OpenBinaryStream();
-            ClientContext.ExecuteQueryRetry();
+            _sourceContext.ExecuteQueryRetry();
             if (string.IsNullOrWhiteSpace(filename)) filename = srcFile.Name;
             targetFolder.UploadFile(filename, binaryStream.Value, OverwriteIfAlreadyExists);
-            targetFolder.Context.ExecuteQueryRetry();
+            _targetContext.ExecuteQueryRetry();
         }
     }
 }

--- a/Commands/Files/CopyFile.cs
+++ b/Commands/Files/CopyFile.cs
@@ -1,8 +1,12 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Linq.Expressions;
+using System.Management.Automation;
+using System.Text.RegularExpressions;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
 using OfficeDevPnP.Core.Utilities;
+using File = Microsoft.SharePoint.Client.File;
 
 namespace SharePointPnP.PowerShell.Commands.Files
 {
@@ -12,15 +16,15 @@ namespace SharePointPnP.PowerShell.Commands.Files
         Category = CmdletHelpCategory.Files)]
     [CmdletExample(
         Remarks = "Copies a file named company.docx located in the document library called Documents located in the projects sitecollection under the managed path sites to the site collection otherproject located in the managed path sites. If a file named company.aspx already exists, it won't perform the copy.",
-        Code = @"PS:>Move-PnPFile -ServerRelativeUrl /sites/project/Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx",
+        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx",
         SortOrder = 1)]
     [CmdletExample(
         Remarks = "Copies a file named company.docx located in the document library called Documents located in the current site to the Documents library in the site collection otherproject located in the managed path sites. If a file named company.aspx already exists, it won't perform the copy.",
-        Code = @"PS:>Move-PnPFile -SiteRelativeUrl Documents/company.aspx -TargetUrl /sites/otherproject/Documents/company.docx",
+        Code = @"PS:>Copy-PnPFile -SiteRelativeUrl Documents/company.aspx -TargetUrl /sites/otherproject/Documents/company.docx",
         SortOrder = 2)]
     [CmdletExample(
         Remarks = "Copies a file named company.docx located in the document library called Documents located in the projects sitecollection under the managed path sites to the site collection otherproject located in the managed path sites. If a file named company.aspx already exists, it will still perform the copy and replace the original company.aspx file.",
-        Code = @"PS:>Move-PnPFile -ServerRelativeUrl /sites/project/Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx -OverwriteIfAlreadyExists",
+        Code = @"PS:>Copy-PnPFile -ServerRelativeUrl /sites/project/Documents/company.docx -TargetUrl /sites/otherproject/Documents/company.docx -OverwriteIfAlreadyExists",
         SortOrder = 3)]
 
     public class CopyFile : SPOWebCmdlet
@@ -40,6 +44,9 @@ namespace SharePointPnP.PowerShell.Commands.Files
         [Parameter(Mandatory = false, HelpMessage = "If provided, no confirmation will be requested and the action will be performed")]
         public SwitchParameter Force;
 
+        [Parameter(Mandatory = false, HelpMessage = "If provided, the source folder name will not be created, only the contents within it.")]
+        public SwitchParameter SkipSourceFolder;
+
         protected override void ExecuteCmdlet()
         {
             if (ParameterSetName == "SITE")
@@ -49,17 +56,97 @@ namespace SharePointPnP.PowerShell.Commands.Files
             }
 
             var file = SelectedWeb.GetFileByServerRelativeUrl(ServerRelativeUrl);
-
-            ClientContext.Load(file, f => f.Name);
+            var folder = SelectedWeb.GetFolderByServerRelativeUrl(ServerRelativeUrl);
+            ClientContext.Load(file, f => f.Name, f => f.Exists);
             ClientContext.ExecuteQueryRetry();
+            ClientContext.Load(folder, f => f.Name, f => f.Exists);
+            ClientContext.ExecuteQueryRetry();
+            bool srcIsFolder = folder.Exists;
 
             if (Force || ShouldContinue(string.Format(Resources.CopyFile0To1, ServerRelativeUrl, TargetUrl), Resources.Confirm))
             {
-                file.CopyTo(TargetUrl, OverwriteIfAlreadyExists);
-
+                Uri uri = new Uri(ClientContext.Url);
+                Uri targetUri = new Uri(uri, TargetUrl);
+                var webUrl = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
+                var srcSite = ClientContext.Site;
+                ClientContext.Load(srcSite, s => s.Url);
                 ClientContext.ExecuteQueryRetry();
+
+                var targetContext = ClientContext.Clone(webUrl.AbsoluteUri);
+                var dstSite = targetContext.Site;
+                targetContext.Load(dstSite, s => s.Url);
+                targetContext.ExecuteQueryRetry();
+                if (srcSite.Url == dstSite.Url)
+                {
+                    //same site collection
+                    file.CopyTo(TargetUrl, OverwriteIfAlreadyExists);
+                    ClientContext.ExecuteQueryRetry();
+                }
+                else
+                {
+                    //different site collections
+                    Folder targetFolder = null;
+                    string fileOrFolderName = null;
+                    try
+                    {
+                        targetFolder = targetContext.Web.GetFolderByServerRelativeUrl(TargetUrl);
+                        targetContext.Load(targetFolder, f => f.Name, f => f.Exists);
+                        targetContext.ExecuteQueryRetry();
+                    }
+                    catch (Exception)
+                    {
+                        Expression<Func<List, object>> expressionRelativeUrl = l => l.RootFolder.ServerRelativeUrl;
+                        var query = targetContext.Web.Lists.IncludeWithDefaultProperties(expressionRelativeUrl);
+                        var lists = targetContext.LoadQuery(query);
+                        targetContext.ExecuteQueryRetry();
+                        foreach (List targetList in lists)
+                        {
+                            if (!TargetUrl.StartsWith(targetList.RootFolder.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase)) continue;
+                            fileOrFolderName = Regex.Replace(TargetUrl, targetList.RootFolder.ServerRelativeUrl, "", RegexOptions.IgnoreCase).Trim('/');
+                            targetFolder = srcIsFolder ? targetList.RootFolder.EnsureFolder(fileOrFolderName) : targetList.RootFolder;
+                            break;
+                        }
+                    }
+                    if (targetFolder == null) throw new Exception("Target does not exist");
+                    if (srcIsFolder)
+                    {
+                        if (!SkipSourceFolder)
+                        {
+                            targetFolder = targetFolder.EnsureFolder(folder.Name);
+                        }
+                        CopyFolder(folder, targetFolder);
+                    }
+                    else
+                    {
+                        UploadFile(file, targetFolder, fileOrFolderName);
+                    }
+                }
             }
+        }
+
+        private void CopyFolder(Folder sourceFolder, Folder targetFolder)
+        {
+            ClientContext.Load(sourceFolder, f => f.Files, f => f.Folders);
+            ClientContext.ExecuteQueryRetry();
+
+            foreach (File file in sourceFolder.Files)
+            {
+                UploadFile(file, targetFolder);
+            }
+            foreach (Folder folder in sourceFolder.Folders)
+            {
+                var childFolder = targetFolder.EnsureFolder(folder.Name);
+                CopyFolder(folder, childFolder);
+            }
+        }
+
+        private void UploadFile(File srcFile, Folder targetFolder, string filename = "")
+        {
+            var binaryStream = srcFile.OpenBinaryStream();
+            ClientContext.ExecuteQueryRetry();
+            if (string.IsNullOrWhiteSpace(filename)) filename = srcFile.Name;
+            targetFolder.UploadFile(filename, binaryStream.Value, OverwriteIfAlreadyExists);
+            targetFolder.Context.ExecuteQueryRetry();
         }
     }
 }
- 

--- a/Commands/Files/CopyFile.cs
+++ b/Commands/Files/CopyFile.cs
@@ -89,21 +89,20 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
-            var sourceServerRelativeUrl = SourceUrl ?? ServerRelativeUrl;
+            SourceUrl = SourceUrl ?? ServerRelativeUrl;
             var webServerRelativeUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
-            if (!string.IsNullOrEmpty(SourceUrl) && !SourceUrl.StartsWith(webServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
+
+            if (!SourceUrl.StartsWith("/"))
             {
-                sourceServerRelativeUrl = UrlUtility.Combine(webServerRelativeUrl, SourceUrl);
+                SourceUrl = UrlUtility.Combine(webServerRelativeUrl, SourceUrl);
             }
             if (!TargetUrl.StartsWith("/"))
             {
-                //site relative URL
                 TargetUrl = UrlUtility.Combine(webServerRelativeUrl, TargetUrl);
             }
 
             Uri currentContextUri = new Uri(ClientContext.Url);
-
-            Uri sourceUri = new Uri(currentContextUri, sourceServerRelativeUrl);
+            Uri sourceUri = new Uri(currentContextUri, SourceUrl);
             Uri sourceWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, sourceUri);
             Uri targetUri = new Uri(currentContextUri, TargetUrl);
             Uri targetWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
@@ -114,13 +113,13 @@ namespace SharePointPnP.PowerShell.Commands.Files
                 _sourceContext = ClientContext.Clone(sourceWebUri);
             }
 
-            File file = _sourceContext.Web.GetFileByServerRelativeUrl(sourceServerRelativeUrl);
-            Folder folder = _sourceContext.Web.GetFolderByServerRelativeUrl(sourceServerRelativeUrl);
+            File file = _sourceContext.Web.GetFileByServerRelativeUrl(SourceUrl);
+            Folder folder = _sourceContext.Web.GetFolderByServerRelativeUrl(SourceUrl);
             file.EnsureProperties(f => f.Name, f => f.Exists);
             folder.EnsureProperties(f => f.Name, f => f.Exists);
             bool srcIsFolder = folder.Exists;
             
-            if (Force || ShouldContinue(string.Format(Resources.CopyFile0To1, sourceServerRelativeUrl, TargetUrl), Resources.Confirm))
+            if (Force || ShouldContinue(string.Format(Resources.CopyFile0To1, SourceUrl, TargetUrl), Resources.Confirm))
             {
                 var srcWeb = _sourceContext.Web;
                 srcWeb.EnsureProperty(s => s.Url);


### PR DESCRIPTION
## Type ##
- [ x] Bug Fix
- [ x] New Feature

## What is in this Pull Request ? ##
The existing code uses file.CopyTo which only works within the same web, while the samples stated otherwise. I have added code which allows copying of a file or folder from the current context to any other site/site collection. If source/target is the same web, it will try to use .CopyTo first.

I also added a switch **SkipSourceFolderName** to be used for folder copy if you only want the contents of the folder, and not the folder itself in the target destination.

Examples have been corrected and added more for folder copying.