### PR TITLE
Check if lists exist before loading properties

### DIFF
--- a/Commands/Lists/GetList.cs
+++ b/Commands/Lists/GetList.cs
@@ -38,12 +38,11 @@ namespace SharePointPnP.PowerShell.Commands.Lists
             DefaultRetrievalExpressions = new Expression<Func<List, object>>[] { l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.RootFolder.ServerRelativeUrl };
 
             var expressions = RetrievalExpressions.ToList();
-            
+
             if (Identity != null)
             {
                 var list = Identity.GetList(SelectedWeb);
-
-                list.EnsureProperties(expressions.ToArray());
+                list?.EnsureProperties(expressions.ToArray());
 
                 WriteObject(list);
 


### PR DESCRIPTION
## Type ##
- [ x] Bug Fix

## What is in this Pull Request ? ##
Check if string is not null before loading properties to avoid getting ObjectReference error in the console. If list does not exist, return null.