### PR TITLE
Enable Get-PnPUserProfileProperty for on-premises

### DIFF
--- a/Commands/UserProfiles/GetUserProfileProperty.cs
+++ b/Commands/UserProfiles/GetUserProfileProperty.cs
@@ -1,5 +1,4 @@
-﻿#if !ONPREMISES
-using System.Management.Automation;
+﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.UserProfiles;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
@@ -9,11 +8,13 @@ namespace SharePointPnP.PowerShell.Commands.UserProfiles
 {
     [Cmdlet(VerbsCommon.Get, "PnPUserProfileProperty")]
     [CmdletAlias("Get-SPOUserProfileProperty")]
+#if !ONPREMISES
     [CmdletHelp(@"You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this cmdlet. 
 ", DetailedDescription = "Requires a connection to a SharePoint Tenant Admin site.", 
         Category = CmdletHelpCategory.UserProfiles,
          OutputType = typeof(PersonProperties),
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.userprofiles.personproperties.aspx")]
+#endif
     [CmdletExample(
         Code = @"PS:> Get-PnPUserProfileProperty -Account 'user@domain.com'", 
         Remarks = "Returns the profile properties for the specified user",
@@ -33,9 +34,14 @@ namespace SharePointPnP.PowerShell.Commands.UserProfiles
 
             foreach (var acc in Account)
             {
-                var result = Tenant.EncodeClaim(acc);
+                var currentAccount = acc;
+#if !ONPREMISES
+                var result = Tenant.EncodeClaim(currentAccount);
                 ClientContext.ExecuteQueryRetry();
-                var properties = peopleManager.GetPropertiesFor(result.Value);
+                currentAccount = result.Value;
+#endif
+
+                var properties = peopleManager.GetPropertiesFor(currentAccount);
                 ClientContext.Load(properties);
                 ClientContext.ExecuteQueryRetry();
                 WriteObject(properties);
@@ -43,4 +49,3 @@ namespace SharePointPnP.PowerShell.Commands.UserProfiles
         }
     }
 }
-#endif

--- a/Commands/UserProfiles/SetUserProfileProperty.cs
+++ b/Commands/UserProfiles/SetUserProfileProperty.cs
@@ -1,5 +1,4 @@
-﻿#if !ONPREMISES
-using System.Management.Automation;
+﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.UserProfiles;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
@@ -10,11 +9,13 @@ namespace SharePointPnP.PowerShell.Commands.UserProfiles
 {
     [Cmdlet(VerbsCommon.Set, "PnPUserProfileProperty")]
     [CmdletAlias("Set-SPOUserProfileProperty")]
-    [CmdletHelp(@"Office365 only: Uses the tenant API to retrieve site information.
+#if !ONPREMISES
+    [CmdletHelp(@"For Office365: Uses the tenant API to retrieve site information.
 
 You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this command. 
 ", DetailedDescription = "Requires a connection to a SharePoint Tenant Admin site.",
         Category = CmdletHelpCategory.UserProfiles)]
+#endif
     [CmdletExample(
         Code = @"PS:> Set-PnPUserProfileProperty -Account 'user@domain.com' -Property 'SPS-Location' -Value 'Stockholm'",
         Remarks = "Sets the SPS-Location property for the user as specified by the Account parameter",
@@ -42,16 +43,19 @@ You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint
         {
             var peopleManager = new PeopleManager(ClientContext);
 
+#if !ONPREMISES
             var result = Tenant.EncodeClaim(Account);
             ClientContext.ExecuteQueryRetry();
+            Account = result.Value;
+#endif
 
             if (ParameterSetName == "Single")
             {
-                peopleManager.SetSingleValueProfileProperty(result.Value, PropertyName, Value);
+                peopleManager.SetSingleValueProfileProperty(Account, PropertyName, Value);
             }
             else
             {
-                peopleManager.SetMultiValuedProfileProperty(result.Value, PropertyName, Values.ToList());
+                peopleManager.SetMultiValuedProfileProperty(Account, PropertyName, Values.ToList());
             }
 
             ClientContext.ExecuteQueryRetry();
@@ -59,4 +63,3 @@ You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint
         }
     }
 }
-#endif

--- a/Commands/UserProfiles/SetUserProfileProperty.cs
+++ b/Commands/UserProfiles/SetUserProfileProperty.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿#if !ONPREMISES
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.UserProfiles;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
@@ -9,13 +10,11 @@ namespace SharePointPnP.PowerShell.Commands.UserProfiles
 {
     [Cmdlet(VerbsCommon.Set, "PnPUserProfileProperty")]
     [CmdletAlias("Set-SPOUserProfileProperty")]
-#if !ONPREMISES
-    [CmdletHelp(@"For Office365: Uses the tenant API to retrieve site information.
+    [CmdletHelp(@"Office365 only: Uses the tenant API to retrieve site information.
 
 You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint.com) with Connect-PnPOnline in order to use this command. 
 ", DetailedDescription = "Requires a connection to a SharePoint Tenant Admin site.",
         Category = CmdletHelpCategory.UserProfiles)]
-#endif
     [CmdletExample(
         Code = @"PS:> Set-PnPUserProfileProperty -Account 'user@domain.com' -Property 'SPS-Location' -Value 'Stockholm'",
         Remarks = "Sets the SPS-Location property for the user as specified by the Account parameter",
@@ -43,19 +42,16 @@ You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint
         {
             var peopleManager = new PeopleManager(ClientContext);
 
-#if !ONPREMISES
             var result = Tenant.EncodeClaim(Account);
             ClientContext.ExecuteQueryRetry();
-            Account = result.Value;
-#endif
 
             if (ParameterSetName == "Single")
             {
-                peopleManager.SetSingleValueProfileProperty(Account, PropertyName, Value);
+                peopleManager.SetSingleValueProfileProperty(result.Value, PropertyName, Value);
             }
             else
             {
-                peopleManager.SetMultiValuedProfileProperty(Account, PropertyName, Values.ToList());
+                peopleManager.SetMultiValuedProfileProperty(result.Value, PropertyName, Values.ToList());
             }
 
             ClientContext.ExecuteQueryRetry();
@@ -63,3 +59,4 @@ You must connect to the tenant admin website (https://:<tenant>-admin.sharepoint
         }
     }
 }
+#endif


### PR DESCRIPTION
## Type ##
- [ x] Bug Fix

## What is in this Pull Request ? ##
On-premises CSOM support getting properties using *PeopleManager*. I moved the #if !ONPREMISES statement around the parts that relate to O365 on tenant management and encoding the claim.

Another solution would be to try/catch on *Tenant.EncodeClaim(Account)* or some other method to check if you are on a tenant or not.