### PR TITLE
New cmd-let Set-PnPWebPermission to manage permissions of a web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+# TabsStudio
+*.tss

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -594,6 +594,7 @@
     <Compile Include="Web\AddIndexedProperty.cs" />
     <Compile Include="Files\RemoveFolder.cs" />
     <Compile Include="Web\RemoveWeb.cs" />
+    <Compile Include="Web\SetWebPermission.cs" />
     <Compile Include="Web\SetRequestAccessEmails.cs" />
     <Compile Include="Workflows\AddWorkflowDefinition.cs" />
     <Compile Include="Workflows\ResumeWorkflowInstance.cs" />

--- a/Commands/Web/SetWebPermission.cs
+++ b/Commands/Web/SetWebPermission.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using SharePointPnP.PowerShell.Commands.Extensions;
+
+namespace SharePointPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Set, "PnPWebPermission", DefaultParameterSetName = "User")]
+    [CmdletAlias("Set-SPOWebPermission")]
+    [CmdletHelp("Sets web permissions",
+        Category = CmdletHelpCategory.Webs)]
+    [CmdletExample(
+        Code = "PS:> Set-PnPWebPermission -Url projectA -User 'user@contoso.com' -AddRole 'Contribute'",
+        Remarks = "Adds the 'Contribute' permission to the user 'user@contoso.com' for a web, specified by its site relative url",
+        SortOrder = 1)]        
+    [CmdletExample(
+        Code = "PS:> Set-PnPWebPermission -Identity 5fecaf67-6b9e-4691-a0ff-518fc9839aa0 -User 'user@contoso.com' -RemoveRole 'Contribute'",
+        Remarks = "Removes the 'Contribute' permission to the user 'user@contoso.com' for a web, specified by its ID",
+        SortOrder = 2)]        
+    public class SetWebPermission : PnPWebCmdlet
+    {
+		[Parameter(Mandatory = true, HelpMessage = "Identity/Id/Web object", ParameterSetName = "GroupByWebIdentity", ValueFromPipeline = true)]
+		[Parameter(Mandatory = true, HelpMessage = "Identity/Id/Web object", ParameterSetName = "UserByWebIdentity", ValueFromPipeline = true)]
+		public WebPipeBind Identity;
+
+		[Parameter(Mandatory = true, HelpMessage = "The site relative url of the web, e.g. 'Subweb1'", ParameterSetName = "GroupByWebUrl")]
+		[Parameter(Mandatory = true, HelpMessage = "The site relative url of the web, e.g. 'Subweb1'", ParameterSetName = "UserByWebUrl")]
+		public string Url;
+
+		[Parameter(Mandatory = true, ParameterSetName = "Group")]
+		[Parameter(Mandatory = true, ParameterSetName = "GroupByWebIdentity")]
+		[Parameter(Mandatory = true, ParameterSetName = "GroupByWebUrl")]
+		public GroupPipeBind Group;
+
+        [Parameter(Mandatory = true, ParameterSetName = "User")]
+        [Parameter(Mandatory = true, ParameterSetName = "UserByWebIdentity")]
+        [Parameter(Mandatory = true, ParameterSetName = "UserByWebUrl")]
+        public string User;
+
+        [Parameter(Mandatory = false, HelpMessage = "The role that must be assigned to the group or user", ParameterSetName = ParameterAttribute.AllParameterSets)]
+		public string[] AddRole = null;
+
+        [Parameter(Mandatory = false, HelpMessage = "The role that must be removed from the group or user", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public string[] RemoveRole = null;
+
+        protected override void ExecuteCmdlet()
+		{
+			// Get Web
+			Web web = SelectedWeb;
+			if (ParameterSetName == "GroupByWebIdentity" || ParameterSetName == "UserByWebIdentity")
+			{
+				if (Identity.Id != Guid.Empty)
+				{
+					web = ClientContext.Web.GetWebById(Identity.Id);
+				}
+				else if (Identity.Web != null)
+				{
+					web = Identity.Web;
+				}
+				else if (Identity.Url != null)
+				{
+					web = ClientContext.Web.GetWebByUrl(Identity.Url);
+				}
+			}
+			else if (ParameterSetName == "GroupByWebUrl" || ParameterSetName == "UserByWebUrl")
+			{
+				web = SelectedWeb.GetWeb(Url);
+			}
+
+			// Set permissions
+			Principal principal = null;
+			if (ParameterSetName == "Group" || ParameterSetName == "GroupByWebUrl" || ParameterSetName == "GroupByWebIdentity")
+			{
+				if (Group.Id != -1)
+				{
+					principal = web.SiteGroups.GetById(Group.Id);
+				}
+				else if (!string.IsNullOrEmpty(Group.Name))
+				{
+					principal = web.SiteGroups.GetByName(Group.Name);
+				}
+				else if (Group.Group != null)
+				{
+					principal = Group.Group;
+				}
+			}
+			else
+			{
+				principal = web.EnsureUser(User);
+			}
+			if (principal != null)
+			{
+				if (AddRole != null)
+				{
+					foreach (var role in AddRole)
+					{
+						web.AddPermissionLevelToPrincipal(principal, role);
+					}
+				}
+				if (RemoveRole != null)
+				{
+					foreach (var role in RemoveRole)
+					{
+						web.RemovePermissionLevelFromPrincipal(principal, role);
+					}
+				}
+			}
+			else
+			{
+				WriteError(new ErrorRecord(new Exception("Principal not found"), "1", ErrorCategory.ObjectNotFound, null));
+			}
+		}
+	}
+}

--- a/Tests/SharePointPnP.PowerShell.Tests.csproj
+++ b/Tests/SharePointPnP.PowerShell.Tests.csproj
@@ -276,6 +276,7 @@
     <Compile Include="FieldsTests.cs" />
     <Compile Include="InvokeWebActionTest.cs" />
     <Compile Include="ListDataRowProvisioningTemplate.cs" />
+    <Compile Include="WebTests.cs" />
     <Compile Include="ProvisioningTemplateFromFolderTest.cs" />
     <Compile Include="WebPartsTests.cs" />
     <Compile Include="ListsTests.cs" />

--- a/Tests/WebTests.cs
+++ b/Tests/WebTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.SharePoint.Client;
+using System.Management.Automation.Runspaces;
+using System.Collections;
+using System.Linq;
+
+namespace SharePointPnP.PowerShell.Tests
+{
+    [TestClass]
+    public class WebTests
+	{
+		[TestInitialize]
+		public void Initialize()
+		{
+			using (var ctx = TestCommon.CreateClientContext())
+			{
+				ctx.Web.Webs.Add(new WebCreationInformation()
+				{
+					Title = "PnPTestWeb",
+					Url = "PnPTestWeb",
+					WebTemplate = "STS#0",
+					UseSamePermissionsAsParentSite = false
+				});
+				ctx.ExecuteQueryRetry();
+			}
+		}
+
+		[TestCleanup]
+		public void Cleanup()
+		{
+			using (var ctx = TestCommon.CreateClientContext())
+			{
+				ctx.Web.DeleteWeb("PnPTestWeb");
+				ctx.Web.DeleteWeb("PnPTestWeb2");
+			}
+		}
+
+		[TestMethod]
+        public void NewWebTest()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                var results = scope.ExecuteCommand("New-PnPWeb",
+                    new CommandParameter("Title", "PnPTestWeb2"),
+                    new CommandParameter("Url", "PnPTestWeb2"),
+					new CommandParameter("Template", "STS#1"));
+				
+				Assert.IsTrue(results.Any());
+                Assert.IsTrue(results[0].BaseObject.GetType() == typeof(Microsoft.SharePoint.Client.Web));
+            }
+		}
+
+		[TestMethod]
+		public void SetWebPermissionByWebUrlTest()
+		{
+			string webUrl = "PnPTestWeb";
+			string group = "Excel Services Viewers";
+
+			// Execute cmd-let
+			using (var scope = new PSTestScope(true))
+			{
+				var results = scope.ExecuteCommand("Set-PnPWebPermission",
+					new CommandParameter("Url", "PnPTestWeb"),
+					new CommandParameter("Group", group),
+					new CommandParameter("AddRole", "Contribute"));
+			}
+
+			// Check that permission is added
+			using (var ctx = TestCommon.CreateClientContext())
+			{
+				var web = ctx.Web.GetWeb(webUrl);
+				var roles = web.RoleAssignments;
+				ctx.Load(roles, role => role.Include(r => r.Member));
+				ctx.ExecuteQueryRetry();
+
+				Assert.IsTrue(roles[0].Member.LoginName == group);
+			}
+		}
+
+		[TestMethod]
+		public void SetWebPermissionByWebIdTest()
+		{
+			string webUrl = "PnPTestWeb";
+			string group = "Excel Services Viewers";
+
+			using (var ctx = TestCommon.CreateClientContext())
+			{
+				// Get PnPTestWeb ID
+				var web = ctx.Web.GetWeb(webUrl);
+				web.EnsureProperty(w => w.Id);
+
+				// Execute cmd-let
+				using (var scope = new PSTestScope(true))
+				{
+					var results = scope.ExecuteCommand("Set-PnPWebPermission",
+						new CommandParameter("Identity", web.Id),
+						new CommandParameter("Group", group),
+						new CommandParameter("AddRole", "Contribute"));
+				}
+
+				// Check that permission is added
+				var roles = web.RoleAssignments;
+				ctx.Load(roles, role => role.Include(r => r.Member));
+				ctx.ExecuteQueryRetry();
+
+				Assert.IsTrue(roles[0].Member.LoginName == group);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #716

## What is in this Pull Request ? ##
Introduced a new cmd-let **Set-PnPWebPermission** to manage web permissions like **Set-PnPListPermission** for lists.