### PR TITLE
Added IgnoreDuplicateDataRowErrors

### DIFF
--- a/Commands/Provisioning/ApplyProvisioningTemplate.cs
+++ b/Commands/Provisioning/ApplyProvisioningTemplate.cs
@@ -71,6 +71,9 @@ PS:> Apply-PnPProvisioningTemplate -Path NewTemplate.xml -ExtensibilityHandlers 
         [Parameter(Mandatory = false, HelpMessage = "Specify this parameter if you want to overwrite and/or create properties that are known to be system entries (starting with vti_, dlc_, etc.)", ParameterSetName = ParameterAttribute.AllParameterSets)]
         public SwitchParameter OverwriteSystemPropertyBagValues;
 
+        [Parameter(Mandatory = false, HelpMessage = "Ignore duplicate data row errors when the the data row in the template already exists.", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public SwitchParameter IgnoreDuplicateDataRowErrors;
+
         [Parameter(Mandatory = false, HelpMessage = "If set content types will be provisioned if the target web is a subweb.")]
         public SwitchParameter ProvisionContentTypesToSubWebs;
         [Parameter(Mandatory = false, HelpMessage = "Override the RemoveExistingNodes attribute in the Navigation elements of the template. If you specify this value the navigation nodes will always be removed before adding the nodes in the template")]
@@ -322,6 +325,7 @@ PS:> Apply-PnPProvisioningTemplate -Path NewTemplate.xml -ExtensibilityHandlers 
             };
 
             applyingInformation.OverwriteSystemPropertyBagValues = OverwriteSystemPropertyBagValues;
+            applyingInformation.IgnoreDuplicateDataRowErrors = IgnoreDuplicateDataRowErrors;
             applyingInformation.ClearNavigation = ClearNavigation;
             applyingInformation.ProvisionContentTypesToSubWebs = ProvisionContentTypesToSubWebs;
 

--- a/Commands/Provisioning/ApplyProvisioningTemplate.cs
+++ b/Commands/Provisioning/ApplyProvisioningTemplate.cs
@@ -71,7 +71,7 @@ PS:> Apply-PnPProvisioningTemplate -Path NewTemplate.xml -ExtensibilityHandlers 
         [Parameter(Mandatory = false, HelpMessage = "Specify this parameter if you want to overwrite and/or create properties that are known to be system entries (starting with vti_, dlc_, etc.)", ParameterSetName = ParameterAttribute.AllParameterSets)]
         public SwitchParameter OverwriteSystemPropertyBagValues;
 
-        [Parameter(Mandatory = false, HelpMessage = "Ignore duplicate data row errors when the the data row in the template already exists.", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        [Parameter(Mandatory = false, HelpMessage = "Ignore duplicate data row errors when the data row in the template already exists.", ParameterSetName = ParameterAttribute.AllParameterSets)]
         public SwitchParameter IgnoreDuplicateDataRowErrors;
 
         [Parameter(Mandatory = false, HelpMessage = "If set content types will be provisioned if the target web is a subweb.")]


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #723 

## What is in this Pull Request ? ##
I added the IgnoreDuplicateDataRowErrors switch to the ApplyProvisioningTemplate command, so a template with DataRows can be provisioned multiple times, without giving errors on duplicate data rows.

