### PR TITLE
Proxy cmdlets for Copy-Item and Move-Item

### DIFF
--- a/Commands/Base/DisconnectSPOnline.cs
+++ b/Commands/Base/DisconnectSPOnline.cs
@@ -29,8 +29,6 @@ namespace SharePointPnP.PowerShell.Commands.Base
                 var drives = Host.Version.Major >= 5 ? provider.Drives.Where(d => d.Provider.Module.ImplementingAssembly.FullName == Assembly.GetExecutingAssembly().FullName) : provider.Drives;
                 foreach (var drive in drives)
                 {
-                    var spoDrive = drive as SPODriveInfo;
-                    spoDrive.ClearState();
                     SessionState.Drive.Remove(drive.Name, true, "Global");
                 }
             }

--- a/Commands/Extensions/ClientObjectExtensions.cs
+++ b/Commands/Extensions/ClientObjectExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace SharePointPnP.PowerShell.Commands.Extensions
 {
@@ -50,6 +51,13 @@ namespace SharePointPnP.PowerShell.Commands.Extensions
             var exp = Expression.Lambda<Func<T, object>>(Expression.Convert(body, typeof(object)), parameter);
 
             return exp;
+        }
+
+        internal static void ClearObjectData(this ClientObject clientObject)
+        {
+            var info_ClientObject_ObjectData = typeof(ClientObject).GetProperty("ObjectData", BindingFlags.NonPublic | BindingFlags.Instance);
+            var objectData = (ClientObjectData)info_ClientObject_ObjectData.GetValue(clientObject, new object[0]);
+            objectData.MethodReturnObjects.Clear();
         }
     }
 }

--- a/Commands/Provider/Parameters/SPODriveParameters.cs
+++ b/Commands/Provider/Parameters/SPODriveParameters.cs
@@ -19,5 +19,8 @@ namespace SharePointPnP.PowerShell.Commands.Provider.Parameters
 
         [Parameter(HelpMessage = "Timeout for caching webs in milliseconds. Default: 600000 (10 minutes).")]
         public int WebCacheTimeout { get; set; }
+
+        [Parameter(HelpMessage = "Don't add aliases (Copy-Item, Move-Item) for proxy cmdlets (Copy-PnPItemProxy, Move-PnPItemProxy.")]
+        public SwitchParameter NoProxyCmdLets { get; set; }
     }
 }

--- a/Commands/Provider/SPOProvider.cs
+++ b/Commands/Provider/SPOProvider.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.Commands.Base;
+using SharePointPnP.PowerShell.Commands.Extensions;
 using SharePointPnP.PowerShell.Commands.Provider.Parameters;
 using SharePointPnP.PowerShell.Commands.Provider.SPOProxy;
 using File = Microsoft.SharePoint.Client.File;
@@ -601,6 +602,9 @@ namespace SharePointPnP.PowerShell.Commands.Provider
 
         private object ExecuteObjectSearch(string serverRelativePath, Web web)
         {
+            //Workaround for CSOM v15.0 to not get deleted items from object data
+            web.ClearObjectData();
+
             var ctx = web.Context;
             File file;
             Folder folder;

--- a/Commands/Provider/SPOProvider.cs
+++ b/Commands/Provider/SPOProvider.cs
@@ -895,21 +895,22 @@ namespace SharePointPnP.PowerShell.Commands.Provider
                 else if (source is Folder && !targetIsFile)
                 {
                     var sourceFolder = source as Folder;
-
                     var rootFolder = (endOfPathFolderCreated || !reCreateSourceFolder) ? targetFolder : targetFolder.CreateFolder(sourceFolder.Name);
-                    var folderAndFiles = GetFolderItems(sourceFolder);
 
-                    foreach (var folder in folderAndFiles.OfType<Folder>())
+                    if (recurse)
                     {
-                        var subFolder = rootFolder.CreateFolder(folder.Name);
-                        if (recurse)
+                        var folderAndFiles = GetFolderItems(sourceFolder);
+
+                        foreach (var folder in folderAndFiles.OfType<Folder>())
                         {
-                            CopyMoveImplementation(folder.ServerRelativeUrl, subFolder.ServerRelativeUrl, true, isCopyOperation, false);
+                            var subFolder = rootFolder.CreateFolder(folder.Name);
+                            CopyMoveImplementation(folder.ServerRelativeUrl, subFolder.ServerRelativeUrl, recurse, isCopyOperation, false);
                         }
-                    }
-                    foreach (var file in folderAndFiles.OfType<File>())
-                    {
-                        CopyMoveImplementation(file.ServerRelativeUrl, rootFolder.ServerRelativeUrl, recurse, isCopyOperation);
+
+                        foreach (var file in folderAndFiles.OfType<File>())
+                        {
+                            CopyMoveImplementation(file.ServerRelativeUrl, rootFolder.ServerRelativeUrl, recurse, isCopyOperation);
+                        }
                     }
 
                     if (!isCopyOperation)

--- a/Commands/Provider/SPOProxy/SPOProxyCmdletBase.cs
+++ b/Commands/Provider/SPOProxy/SPOProxyCmdletBase.cs
@@ -1,0 +1,62 @@
+﻿using System.Management.Automation;
+
+namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
+{
+    public abstract class SPOProxyCmdletBase : PSCmdlet
+    {
+        internal string[] PsPaths { get; private set; }
+
+        internal bool ShouldExpandWildcards { get; private set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = "Path", Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        public virtual string[] Path
+        {
+            get { return PsPaths; }
+            set
+            {
+                ShouldExpandWildcards = true;
+                PsPaths = value;
+            }
+        }
+
+        [Parameter(Mandatory = true, ParameterSetName = "LiteralPath", Position = 0, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Alias("PSPath")]
+        public virtual string[] LiteralPath
+        {
+            get { return PsPaths; }
+            set { PsPaths = value; }
+        }
+
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = true)]
+        public virtual string Destination { get; set; }
+
+        [Parameter]
+        public virtual SwitchParameter Container { get; set; }
+
+        [Parameter]
+        public virtual SwitchParameter Force { get; set; }
+
+        [Parameter]
+        public virtual string Filter { get; set; }
+
+        [Parameter]
+        public virtual string[] Include { get; set; }
+
+        [Parameter]
+        public virtual string[] Exclude { get; set; }
+
+        //[Parameter]
+        public virtual SwitchParameter Recurse { get; set; }
+
+        [Parameter]
+        public virtual SwitchParameter PassThru { get; set; }
+
+        [Credential]
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public virtual PSCredential Credential { get; set; }
+
+        internal virtual string CmdletType { get; }
+
+        public const string CmdletNoun = "PnPItemProxy";
+    }
+}

--- a/Commands/Provider/SPOProxy/SPOProxyCopyItem.cs
+++ b/Commands/Provider/SPOProxy/SPOProxyCopyItem.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using Microsoft.PowerShell.Commands;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using File = System.IO.File;
+
+namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
+{
+    [Cmdlet(CmdletVerb, CmdletNoun, DefaultParameterSetName = "Path", SupportsShouldProcess = true, SupportsTransactions = true)]
+    [CmdletHelp("Proxy cmdlet for using Copy-Item between SharePoint provider and FileSystem provider", Category = CmdletHelpCategory.Files)]
+    public class SPOProxyCopyItem : SPOProxyCmdletBase
+    {
+        public const string CmdletVerb = "Copy";
+
+        internal override string CmdletType => CmdletVerb;
+
+        [Parameter]
+        public override SwitchParameter Recurse { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            SPOProxyImplementation.CopyMoveImlementation(this);
+        }
+    }
+}

--- a/Commands/Provider/SPOProxy/SPOProxyImplementation.cs
+++ b/Commands/Provider/SPOProxy/SPOProxyImplementation.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Runtime.Serialization;
+using Microsoft.PowerShell.Commands;
+using Microsoft.SharePoint.Client;
+using File = System.IO.File;
+
+namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
+{
+    internal class SPOProxyImplementation
+    {
+        internal static void AddAlias(SessionState sessionState)
+        {
+            //Set-Alias -Name Copy-Item -Value Copy-PnPItemProxy -Scope 1
+            sessionState.InvokeCommand.InvokeScript($@"Set-Alias -Name Copy-Item -Value {SPOProxyCopyItem.CmdletVerb}-{SPOProxyCmdletBase.CmdletNoun} -Scope 1", false, PipelineResultTypes.None, null, null);
+            sessionState.InvokeCommand.InvokeScript($@"Set-Alias -Name Move-Item -Value {SPOProxyMoveItem.CmdletVerb}-{SPOProxyCmdletBase.CmdletNoun} -Scope 1", false, PipelineResultTypes.None, null, null);
+        }
+
+        internal static void RemoveAlias(SessionState sessionState)
+        {
+            sessionState.InvokeCommand.InvokeScript(@"Remove-Item -Path alias:\Copy-Item -ErrorAction SilentlyContinue", false, PipelineResultTypes.None, null, null);
+            sessionState.InvokeCommand.InvokeScript(@"Remove-Item -Path alias:\Move-Item -ErrorAction SilentlyContinue", false, PipelineResultTypes.None, null, null);
+        }
+
+        internal static void CopyMoveImlementation(SPOProxyCmdletBase cmdlet)
+        {
+            //Flag
+            var isProcessed = false;
+
+            //Destination
+            ProviderInfo destProvider;
+            PSDriveInfo destDrive;
+            var destPath = cmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath(cmdlet.Destination ?? string.Empty, out destProvider, out destDrive).Replace($"{destDrive.Name}:", string.Empty);
+            var destParts = destPath.Split(@"\/".ToCharArray());
+            var destFolderPath = (cmdlet.Container || !destParts.Last().Contains(".")) ? destPath : string.Join(@"\", destParts.Take(destParts.Length - 1));
+            if (string.IsNullOrEmpty(destFolderPath)) destFolderPath = @"\";
+            var destFolderFullPath = $@"{destDrive.Name}:{destFolderPath}";
+            var destIsFile = destPath != destFolderPath;
+
+            //Source
+            var pathInfos = cmdlet.PsPaths.SelectMany(psPath => cmdlet.SessionState.Path.GetResolvedPSPathFromPSPath(psPath)).ToList();
+
+            //Verify all sources uses same provider and that SPOProvider in use
+            if (
+                pathInfos.Any() &&
+                pathInfos.All(p => p.Provider == pathInfos.First().Provider) &&
+                (destProvider.ImplementingType == typeof(SPOProvider) || pathInfos.First().Provider.ImplementingType == typeof(SPOProvider)) &&
+                cmdlet.ShouldProcess($"Source: {string.Join(", ", cmdlet.PsPaths)} to Destination: {destFolderFullPath}", cmdlet.CmdletType)
+                )
+            {
+                var srcProvider = pathInfos.First().Provider;
+
+                //Verify destination file compatibility
+                if (destIsFile && pathInfos.Count() != 1)
+                {
+                    cmdlet.ThrowTerminatingError(new ErrorRecord(new ArgumentException("Can only copy one file to another file"), "Can only copy one file to another file", ErrorCategory.InvalidArgument, cmdlet));
+                }
+
+                if (destIsFile && cmdlet.InvokeProvider.Item.IsContainer(pathInfos.First().Path))
+                {
+                    cmdlet.ThrowTerminatingError(new ErrorRecord(new ArgumentException("Can not copy directory to file"), "Can not copy directory to file", ErrorCategory.InvalidArgument, cmdlet));
+                }
+
+                //Copy from FileSystem to SharePoint
+                if (srcProvider.ImplementingType == typeof(FileSystemProvider) && destProvider.ImplementingType == typeof(SPOProvider))
+                {
+
+                    //Create destination folder
+                    var isDestFolderCreated = !cmdlet.InvokeProvider.Item.Exists(destFolderFullPath);
+                    var folderObj = cmdlet.InvokeProvider.Item.New(new[] { destFolderFullPath }, string.Empty, "Folder", null, cmdlet.Force);
+                    var destFolder = (Folder)folderObj.First().BaseObject;
+
+                    foreach (var pathInfo in pathInfos)
+                    {
+                        if (File.Exists(pathInfo.Path))
+                        {
+                            var fileInfo = new FileInfo(pathInfo.Path);
+                            //destFolder.UploadFile(destIsFile ? destParts.Last() : fileInfo.Name, fileInfo.FullName, Force);
+                            using (var fs = fileInfo.OpenRead())
+                            {
+                                var result = cmdlet.InvokeProvider.Item.New(new[] { $@"{destFolderFullPath}\{(destIsFile ? destParts.Last() : fileInfo.Name)}" }, string.Empty, "File", fs, cmdlet.Force);
+                                HandleResult(result, cmdlet);
+                            }
+                        }
+                        else if (Directory.Exists(pathInfo.Path))
+                        {
+                            var rootDirInfo = new DirectoryInfo(pathInfo.Path);
+                            var rootFolder = isDestFolderCreated ? destFolder : destFolder.CreateFolder(rootDirInfo.Name);
+                            var rootFolderFullPath = isDestFolderCreated ? destFolderFullPath : $@"{destFolderFullPath}\{rootFolder.Name}";
+
+                            if (cmdlet.Recurse)
+                            {
+                                var spoChildItems = cmdlet.InvokeProvider.ChildItem.Get(pathInfo.Path, cmdlet.Recurse);
+                                foreach (var spoChildItem in spoChildItems)
+                                {
+                                    if ((bool)spoChildItem.Properties["PSIsContainer"].Value)
+                                    {
+                                        var childDir = (DirectoryInfo)spoChildItem.BaseObject;
+                                        var childPath = childDir.FullName.Replace(rootDirInfo.FullName, string.Empty);
+                                        var result = cmdlet.InvokeProvider.Item.New(new[] { $@"{rootFolderFullPath}\{childPath}" }, string.Empty, "Folder", null, cmdlet.Force);
+                                        HandleResult(result, cmdlet);
+                                    }
+                                    else
+                                    {
+                                        var childFileInfo = (FileInfo)spoChildItem.BaseObject;
+                                        var childPath = childFileInfo.FullName.Replace(rootDirInfo.FullName, string.Empty);
+                                        using (var fs = childFileInfo.OpenRead())
+                                        {
+                                            var result = cmdlet.InvokeProvider.Item.New(new[] { $@"{rootFolderFullPath}\{childPath}" }, string.Empty, "File", fs, cmdlet.Force);
+                                            HandleResult(result, cmdlet);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    isProcessed = true;
+                }
+                //Copy from SharePoint to FileSystem
+                else if (srcProvider.ImplementingType == typeof(SPOProvider) && destProvider.ImplementingType == typeof(FileSystemProvider))
+                {
+                    //Create destination directory
+                    var isDestDirCreated = !cmdlet.InvokeProvider.Item.Exists(destFolderFullPath);
+                    var dirObject = (destDrive.Root != destFolderFullPath) ? cmdlet.InvokeProvider.Item.New(new[] { destFolderFullPath }, string.Empty, "Directory", null, true) : cmdlet.InvokeProvider.Item.Get(destFolderFullPath);
+                    var destDir = (DirectoryInfo)dirObject.First().BaseObject;
+
+                    foreach (var pathInfo in pathInfos)
+                    {
+                        var spoObjects = cmdlet.InvokeProvider.Item.Get(pathInfo.Path);
+                        foreach (var spoObject in spoObjects)
+                        {
+                            if (spoObject.BaseObject is Microsoft.SharePoint.Client.File)
+                            {
+                                var file = (Microsoft.SharePoint.Client.File)spoObject.BaseObject;
+                                ((ClientContext)file.Context).Web.SaveFileToLocal(file.EnsureProperty(f => f.ServerRelativeUrl), destFolderFullPath, destIsFile ? destParts.Last() : null, s => cmdlet.Force);
+                                HandleResult($@"{destFolderFullPath}\{(destIsFile ? destParts.Last() : file.Name)}", cmdlet);
+                            }
+                            else if (spoObject.BaseObject is Microsoft.SharePoint.Client.Folder)
+                            {
+                                var rootFolder = (Microsoft.SharePoint.Client.Folder)spoObject.BaseObject;
+                                rootFolder.EnsureProperties(p => p.ServerRelativeUrl, p => p.Name);
+                                var rootDirInfo = (isDestDirCreated) ? destDir : destDir.CreateSubdirectory(rootFolder.Name);
+                                HandleResult(rootDirInfo, cmdlet);
+
+                                if (cmdlet.Recurse)
+                                {
+                                    var spoChildItems = cmdlet.InvokeProvider.ChildItem.Get(pathInfo.Path, cmdlet.Recurse);
+                                    foreach (var spoChildItem in spoChildItems)
+                                    {
+                                        if ((bool)spoChildItem.Properties["PSIsContainer"].Value)
+                                        {
+                                            var childFolder = (Microsoft.SharePoint.Client.Folder)spoChildItem.BaseObject;
+                                            childFolder.EnsureProperty(p => p.ServerRelativeUrl);
+                                            var childPath = childFolder.ServerRelativeUrl.Replace(rootFolder.ServerRelativeUrl, string.Empty);
+                                            var result = cmdlet.InvokeProvider.Item.New(new[] { $@"{rootDirInfo.FullName}\{childPath}" }, string.Empty, "Directory", null, cmdlet.Force);
+                                            HandleResult(result, cmdlet);
+                                        }
+                                        else
+                                        {
+                                            var childFile = (Microsoft.SharePoint.Client.File)spoChildItem.BaseObject;
+                                            childFile.EnsureProperty(p => p.ServerRelativeUrl);
+                                            var childParts = childFile.ServerRelativeUrl.Replace(rootFolder.ServerRelativeUrl, string.Empty).Split(@"\/".ToCharArray());
+                                            var childPath = string.Join(@"\", childParts.Take(childParts.Length - 1));
+                                            ((ClientContext)childFile.Context).Web.SaveFileToLocal(childFile.ServerRelativeUrl, $@"{rootDirInfo.FullName}\{childPath}", null, s => cmdlet.Force);
+                                            HandleResult($@"{rootDirInfo.FullName}\{childPath}", cmdlet);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    isProcessed = true;
+                }
+                if (isProcessed && cmdlet.CmdletType == SPOProxyMoveItem.CmdletVerb)
+                {
+                    cmdlet.InvokeProvider.Item.Remove(pathInfos.Select(p => p.Path).ToArray(), true, true, true);
+                }
+            }
+
+            //Cmd not processed transfer to standard provider
+            if (!isProcessed)
+            {
+                cmdlet.WriteObject(cmdlet.InvokeCommand.InvokeScript($@"$args=$args[0];Microsoft.PowerShell.Management\{cmdlet.CmdletType}-Item @args", false, PipelineResultTypes.None, null, new Hashtable(cmdlet.MyInvocation.BoundParameters)));
+                //cmdlet.InvokeProvider.Item.Copy(cmdlet.PsPaths, cmdlet.Destination, cmdlet.Recurse, cmdlet.Container ? CopyContainers.CopyTargetContainer : CopyContainers.CopyChildrenOfTargetContainer, cmdlet.Force, !cmdlet.ShouldExpandWildcards);
+            }
+        }
+
+        private static void HandleResult(string fullPath, SPOProxyCmdletBase cmdlet)
+        {
+            if (cmdlet.PassThru)
+            {
+                cmdlet.WriteObject(cmdlet.InvokeProvider.Item.Get(fullPath));
+            }
+        }
+
+        private static void HandleResult(object result, SPOProxyCmdletBase cmdlet)
+        {
+            if (cmdlet.PassThru)
+            {
+                cmdlet.WriteObject(result);
+            }
+        }
+    }
+}

--- a/Commands/Provider/SPOProxy/SPOProxyImplementation.cs
+++ b/Commands/Provider/SPOProxy/SPOProxyImplementation.cs
@@ -18,8 +18,8 @@ namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
         internal static void AddAlias(SessionState sessionState)
         {
             //Set-Alias -Name Copy-Item -Value Copy-PnPItemProxy -Scope 1
-            sessionState.InvokeCommand.InvokeScript($@"Set-Alias -Name Copy-Item -Value {SPOProxyCopyItem.CmdletVerb}-{SPOProxyCmdletBase.CmdletNoun} -Scope 1", false, PipelineResultTypes.None, null, null);
-            sessionState.InvokeCommand.InvokeScript($@"Set-Alias -Name Move-Item -Value {SPOProxyMoveItem.CmdletVerb}-{SPOProxyCmdletBase.CmdletNoun} -Scope 1", false, PipelineResultTypes.None, null, null);
+            sessionState.InvokeCommand.InvokeScript($@"Set-Alias -Name Copy-Item -Value {SPOProxyCopyItem.CmdletVerb}-{SPOProxyCmdletBase.CmdletNoun} -Scope Global", false, PipelineResultTypes.None, null, null);
+            sessionState.InvokeCommand.InvokeScript($@"Set-Alias -Name Move-Item -Value {SPOProxyMoveItem.CmdletVerb}-{SPOProxyCmdletBase.CmdletNoun} -Scope Global", false, PipelineResultTypes.None, null, null);
         }
 
         internal static void RemoveAlias(SessionState sessionState)
@@ -81,7 +81,6 @@ namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
                         if (File.Exists(pathInfo.Path))
                         {
                             var fileInfo = new FileInfo(pathInfo.Path);
-                            //destFolder.UploadFile(destIsFile ? destParts.Last() : fileInfo.Name, fileInfo.FullName, Force);
                             using (var fs = fileInfo.OpenRead())
                             {
                                 var result = cmdlet.InvokeProvider.Item.New(new[] { $@"{destFolderFullPath}\{(destIsFile ? destParts.Last() : fileInfo.Name)}" }, string.Empty, "File", fs, cmdlet.Force);
@@ -187,7 +186,6 @@ namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
             if (!isProcessed)
             {
                 cmdlet.WriteObject(cmdlet.InvokeCommand.InvokeScript($@"$args=$args[0];Microsoft.PowerShell.Management\{cmdlet.CmdletType}-Item @args", false, PipelineResultTypes.None, null, new Hashtable(cmdlet.MyInvocation.BoundParameters)));
-                //cmdlet.InvokeProvider.Item.Copy(cmdlet.PsPaths, cmdlet.Destination, cmdlet.Recurse, cmdlet.Container ? CopyContainers.CopyTargetContainer : CopyContainers.CopyChildrenOfTargetContainer, cmdlet.Force, !cmdlet.ShouldExpandWildcards);
             }
         }
 

--- a/Commands/Provider/SPOProxy/SPOProxyImplementation.cs
+++ b/Commands/Provider/SPOProxy/SPOProxyImplementation.cs
@@ -73,7 +73,7 @@ namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
 
                     //Create destination folder
                     var isDestFolderCreated = !cmdlet.InvokeProvider.Item.Exists(destFolderFullPath);
-                    var folderObj = cmdlet.InvokeProvider.Item.New(new[] { destFolderFullPath }, string.Empty, "Folder", null, cmdlet.Force);
+                    var folderObj = (destDrive.Root != destFolderFullPath) ? cmdlet.InvokeProvider.Item.New(new[] { destFolderFullPath }, string.Empty, "Folder", null, cmdlet.Force) : cmdlet.InvokeProvider.Item.Get(destFolderFullPath);
                     var destFolder = (Folder)folderObj.First().BaseObject;
 
                     foreach (var pathInfo in pathInfos)

--- a/Commands/Provider/SPOProxy/SPOProxyMoveItem.cs
+++ b/Commands/Provider/SPOProxy/SPOProxyMoveItem.cs
@@ -1,0 +1,21 @@
+﻿using System.Management.Automation;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+
+namespace SharePointPnP.PowerShell.Commands.Provider.SPOProxy
+{
+    [Cmdlet(CmdletVerb, CmdletNoun, DefaultParameterSetName = "Path", SupportsShouldProcess = true, SupportsTransactions = true)]
+    [CmdletHelp("Proxy cmdlet for using Move-Item between SharePoint provider and FileSystem provider", Category = CmdletHelpCategory.Files)]
+    public class SPOProxyMoveItem : SPOProxyCmdletBase
+    {
+        public const string CmdletVerb = "Move";
+
+        internal override string CmdletType => CmdletVerb;
+
+        public override SwitchParameter Recurse => true;
+
+        protected override void ProcessRecord()
+        {
+            SPOProxyImplementation.CopyMoveImlementation(this);
+        }
+    }
+}

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -349,6 +349,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="Microsoft.PowerShell.Commands.Management" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -455,9 +456,13 @@
     <Compile Include="Enums\TargetScope.cs" />
     <Compile Include="Files\GetFolder.cs" />
     <Compile Include="Graph\SetUnifiedGroup.cs" />
+    <Compile Include="Provider\SPOProxy\SPOProxyCmdletBase.cs" />
     <Compile Include="Provider\Parameters\SPOChildItemsParameters.cs" />
     <Compile Include="Provider\Parameters\SPOContentParameters.cs" />
     <Compile Include="Provider\Parameters\SPODriveParameters.cs" />
+    <Compile Include="Provider\SPOProxy\SPOProxyImplementation.cs" />
+    <Compile Include="Provider\SPOProxy\SPOProxyCopyItem.cs" />
+    <Compile Include="Provider\SPOProxy\SPOProxyMoveItem.cs" />
     <Compile Include="Provisioning\AddListFoldersToProvisioningTemplate.cs" />
     <Compile Include="Provisioning\AddDataRowsToProvisioningTemplate.cs" />
     <Compile Include="InformationManagement\ClosureState.cs" />


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related PR ##
This need PR  [PnP-Sites-Core/#1065](https://github.com/SharePoint/PnP-Sites-Core/pull/1065) to be able to save files from SharePoint to FileSystem

## What is in this Pull Request ? ##
Proxy cmdlets to allow the usage of the standard cmdlets Copy-Item and Move-Item between the FileSystem provider and the SharePoint provider. It consist of:
- PnP-Proxy-cmdlets that's handle the actual copying/moving if FileSystem and SharePoint is involved (otherwise the request is transferred to the standard cmdlets).
- Aliases to take over the standard cmdlets names. The aliases will be inserted when a SharePoint drive is created (if not the switch -NoProxyCmdLets is used).

Also in this PR
- Corrected the behavior of Copy-Item to correlate with the FileSystem provider.
- Workaround for CSOM v15 where deleted items are returned from object data (had to copy ClearObjectData from PnP-Sites-Core due to its access level).
