### PR TITLE
Yes/No field example correction

### DIFF
--- a/Commands/Lists/SetListItem.cs
+++ b/Commands/Lists/SetListItem.cs
@@ -54,7 +54,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
             "\n\nMulti value lookup (id of lookup values as array 1): -Values @{\"MultiLookupField\" = \"1\",\"2\"}" +
             "\n\nMulti value lookup (id of lookup values as array 2): -Values @{\"MultiLookupField\" = 1,2}" +
             "\n\nMulti value lookup (id of lookup values as string): -Values @{\"MultiLookupField\" = \"1,2\"}" +
-            "\n\nYes/No: -Values @{\"YesNoField\" = \"No\"}" +
+            "\n\nYes/No: -Values @{\"YesNoField\" = $false}" +
             "\n\nPerson/Group (id of user/group in Site User Info List or email of the user, seperate multiple values with a comma): -Values @{\"PersonField\" = \"user1@domain.com\",\"21\"}" +
             "\n\nManaged Metadata (single value with path to term): -Values @{\"MetadataField\" = \"CORPORATE|DEPARTMENTS|FINANCE\"}" +
             "\n\nManaged Metadata (single value with id of term): -Values @{\"MetadataField\" = \"fe40a95b-2144-4fa2-b82a-0b3d0299d818\"} with Id of term" +


### PR DESCRIPTION
Yes/No field accepts $true or $false in practice, not "Yes" or "No"

## Type ##
- [x ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Updating the example guidance for Yes/No fields.


