### PR TITLE
Set list item permissions

### DIFF
--- a/Commands/Lists/SetListItemPermission.cs
+++ b/Commands/Lists/SetListItemPermission.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Lists
+{
+    //TODO: Create Test
+    [Cmdlet(VerbsCommon.Set, "PnPListItemPermission", DefaultParameterSetName = "User")]
+    [CmdletHelp("Sets list item permissions",
+        Category = CmdletHelpCategory.Lists)]
+    [CmdletExample(
+        Code = "PS:> Set-PnPListPermission -List 'Documents' -Identity 1 -User 'user@contoso.com' -AddRole 'Contribute'",
+        Remarks = "Adds the 'Contribute' permission to the user 'user@contoso.com' for item with id 1 in the list 'Documents'",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = "PS:> Set-PnPListPermission -List 'Documents' -Identity 1 -User 'user@contoso.com' -RemoveRole 'Contribute'",
+        Remarks = "Removes the 'Contribute' permission to the user 'user@contoso.com' for item with id 1 in the list 'Documents'",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = "PS:> Set-PnPListPermission -List 'Documents' -Identity 1 -User 'user@contoso.com' -AddRole 'Contribute' -ClearExisting",
+        Remarks = "Adds the 'Contribute' permission to the user 'user@contoso.com' for item with id 1 in the list 'Documents' and removes all other permissions",
+        SortOrder = 3)]
+    [CmdletExample(
+        Code = "PS:> Set-PnPListPermission -List 'Documents' -Identity 1 -InheritPermissions",
+        Remarks = "Resets permissions for item with id 1 to inherit permissions from the list 'Documents'",
+        SortOrder = 4)]
+    public class SetListItemPermission : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public ListPipeBind List;
+
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The ID of the listitem, or actual ListItem object", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public ListItemPipeBind Identity;
+
+        [Parameter(Mandatory = true, ParameterSetName = "Group")]
+        public GroupPipeBind Group;
+
+        [Parameter(Mandatory = true, ParameterSetName = "User")]
+        public string User;
+
+        [Parameter(Mandatory = false, HelpMessage = "The role that must be assigned to the group or user", ParameterSetName = "User")]
+        [Parameter(Mandatory = false, HelpMessage = "The role that must be assigned to the group or user", ParameterSetName = "Group")]
+        public string AddRole = string.Empty;
+
+        [Parameter(Mandatory = false, HelpMessage = "The role that must be removed from the group or user", ParameterSetName = "User")]
+        [Parameter(Mandatory = false, HelpMessage = "The role that must be removed from the group or user", ParameterSetName = "Group")]
+        public string RemoveRole = string.Empty;
+
+        [Parameter(Mandatory = false, HelpMessage = "Clear all existing permissions", ParameterSetName = "User")]
+        [Parameter(Mandatory = false, HelpMessage = "Clear all existing permissions", ParameterSetName = "Group")]
+        public SwitchParameter ClearExisting;
+
+        [Parameter(Mandatory = false, HelpMessage = "Inherit permissions from the list, removing unique permissions", ParameterSetName = "Inherit")]
+        public SwitchParameter InheritPermissions;
+
+        protected override void ExecuteCmdlet()
+        {
+            List list = null;
+            if (List != null)
+            {
+                list = List.GetList(SelectedWeb);
+            }
+            if (list != null)
+            {
+                var item = Identity.GetListItem(list);
+                if (item != null)
+                {
+                    item.EnsureProperties(i => i.HasUniqueRoleAssignments);
+                    if (item.HasUniqueRoleAssignments && InheritPermissions.IsPresent)
+                    {
+                        item.ResetRoleInheritance();
+                    }
+                    else if (!item.HasUniqueRoleAssignments)
+                    {
+                        item.BreakRoleInheritance(!ClearExisting.IsPresent, true);
+                    }
+                    else if (ClearExisting.IsPresent)
+                    {
+                        item.ResetRoleInheritance();
+                        item.BreakRoleInheritance(!ClearExisting.IsPresent, true);
+                    }
+
+                    item.Update();
+                    ClientContext.ExecuteQueryRetry();
+                    if (ParameterSetName == "Inherit")
+                    {
+                        // no processing of user/group needed
+                        return;
+                    }
+
+                    Principal principal = null;
+                    if (ParameterSetName == "Group")
+                    {
+                        if (Group.Id != -1)
+                        {
+                            principal = SelectedWeb.SiteGroups.GetById(Group.Id);
+                        }
+                        else if (!string.IsNullOrEmpty(Group.Name))
+                        {
+                            principal = SelectedWeb.SiteGroups.GetByName(Group.Name);
+                        }
+                        else if (Group.Group != null)
+                        {
+                            principal = Group.Group;
+                        }
+                    }
+                    else
+                    {
+                        principal = SelectedWeb.EnsureUser(User);
+                        ClientContext.ExecuteQueryRetry();
+                    }
+                    if (principal != null)
+                    {
+                        if (!string.IsNullOrEmpty(AddRole))
+                        {
+                            var roleDefinition = SelectedWeb.RoleDefinitions.GetByName(AddRole);
+                            var roleDefinitionBindings = new RoleDefinitionBindingCollection(ClientContext)
+                            {
+                                roleDefinition
+                            };
+                            var roleAssignments = item.RoleAssignments;
+                            roleAssignments.Add(principal, roleDefinitionBindings);
+                            ClientContext.Load(roleAssignments);
+                            ClientContext.ExecuteQueryRetry();
+                        }
+                        if (!string.IsNullOrEmpty(RemoveRole))
+                        {
+                            var roleAssignment = item.RoleAssignments.GetByPrincipal(principal);
+                            var roleDefinitionBindings = roleAssignment.RoleDefinitionBindings;
+                            ClientContext.Load(roleDefinitionBindings);
+                            ClientContext.ExecuteQueryRetry();
+                            foreach (var roleDefinition in roleDefinitionBindings.Where(roleDefinition => roleDefinition.Name == RemoveRole))
+                            {
+                                roleDefinitionBindings.Remove(roleDefinition);
+                                roleAssignment.Update();
+                                ClientContext.ExecuteQueryRetry();
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        WriteError(new ErrorRecord(new Exception("Principal not found"), "1", ErrorCategory.ObjectNotFound, null));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Commands/Lists/SetListPermission.cs
+++ b/Commands/Lists/SetListPermission.cs
@@ -62,6 +62,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 else
                 {
                     principal = SelectedWeb.EnsureUser(User);
+                    ClientContext.ExecuteQueryRetry();
                 }
                 if (principal != null)
                 {

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -455,6 +455,7 @@
     <Compile Include="Enums\TargetScope.cs" />
     <Compile Include="Files\GetFolder.cs" />
     <Compile Include="Graph\SetUnifiedGroup.cs" />
+    <Compile Include="Lists\SetListItemPermission.cs" />
     <Compile Include="Provider\SPOProxy\SPOProxyCmdletBase.cs" />
     <Compile Include="Provider\Parameters\SPOChildItemsParameters.cs" />
     <Compile Include="Provider\Parameters\SPOContentParameters.cs" />


### PR DESCRIPTION
## Type ##
- [x] New Feature

## What is in this Pull Request ? ##
Commandlet to work with permissions for a list item.
(A small bug fix on resolving users on setpermissions on a list)

Some thoughts - Set-PnPList also has functions to break inheritance, and a separate commandlet to add/remove roles. No functionality to restore inheritance. @erwinvanhunen, would it be useful to add ClearExisting/InheritPermissions switches to the Set-PnPListPermission cmdlet as well? And the Set-PnPListItem has no functionality to break inheritence.