### PR TITLE
Changed import to filepath instead of file content.

### DIFF
--- a/Commands/Search/SetSearchConfiguration.cs
+++ b/Commands/Search/SetSearchConfiguration.cs
@@ -69,7 +69,7 @@ namespace SharePointPnP.PowerShell.Commands.Search
                             throw new InvalidOperationException(Resources.CurrentSiteIsNoTenantAdminSite);
                         }
 
-                        ClientContext.ImportSearchSettings(Configuration, SearchObjectLevel.SPSiteSubscription);
+                        ClientContext.ImportSearchSettings(Path, SearchObjectLevel.SPSiteSubscription);
                         break;
                     }
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes [Set-PnPSearchConfiguration is not working with Tenant Scope](https://github.com/SharePoint/PnP-PowerShell/issues/745)

## What is in this Pull Request ? ##
Changed import to filepath instead of file content (configuration).