### PR TITLE
fix to return the newly created term not the termset

### DIFF
--- a/Commands/Taxonomy/NewTerm.cs
+++ b/Commands/Taxonomy/NewTerm.cs
@@ -126,7 +126,7 @@ namespace SharePointPnP.PowerShell.Commands.Taxonomy
             termStore.CommitAll();
             ClientContext.Load(term);
             ClientContext.ExecuteQueryRetry();
-            WriteObject(termSet);
+            WriteObject(term);
         }
 
     }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
When using `New-PnPTerm` it returns the Term Set it was created in, not the term. This update fixes that.
