### PR TITLE
fix to normalize term name

### DIFF
--- a/Commands/Taxonomy/GetTerm.cs
+++ b/Commands/Taxonomy/GetTerm.cs
@@ -102,7 +102,9 @@ namespace SharePointPnP.PowerShell.Commands.Taxonomy
                 }
                 else
                 {
-                    term = termSet.Terms.GetByName(Identity.StringValue);
+                    var termName = TaxonomyItem.NormalizeName(ClientContext, Identity.StringValue);
+                    ClientContext.ExecuteQueryRetry();
+                    term = termSet.Terms.GetByName(termName.Value);
                 }
                 ClientContext.Load(term, RetrievalExpressions);
                 ClientContext.ExecuteQueryRetry();

--- a/Commands/Taxonomy/NewTerm.cs
+++ b/Commands/Taxonomy/NewTerm.cs
@@ -107,7 +107,9 @@ namespace SharePointPnP.PowerShell.Commands.Taxonomy
             {
                 Id = Guid.NewGuid();
             }
-            var term = termSet.CreateTerm(Name, Lcid, Id);
+            var termName = TaxonomyItem.NormalizeName(ClientContext,Name);
+            ClientContext.ExecuteQueryRetry();
+            var term = termSet.CreateTerm(termName.Value, Lcid, Id);
             ClientContext.Load(term);
             ClientContext.ExecuteQueryRetry();
             term.SetDescription(Description, Lcid);

--- a/Documentation/GetPnPUnifiedGroup.md
+++ b/Documentation/GetPnPUnifiedGroup.md
@@ -3,12 +3,14 @@ Gets one Office 365 Group (aka Unified Group) or a list of Office 365 Groups
 ## Syntax
 ```powershell
 Get-PnPUnifiedGroup [-Identity <UnifiedGroupPipeBind>]
+                    [-ExcludeSiteUrl [<SwitchParameter>]]
 ```
 
 
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
+|ExcludeSiteUrl|SwitchParameter|False|Exclude fetching the site URL for Office 365 Groups. This speeds up large listings.|
 |Identity|UnifiedGroupPipeBind|False|The Identity of the Office 365 Group.|
 ## Examples
 
@@ -32,9 +34,9 @@ Retrieves a specific Office 365 Group based on its DisplayName
 
 ### Example 4
 ```powershell
-PS:> Get-PnPUnifiedGroup -Identity $groupSiteUrl
+PS:> Get-PnPUnifiedGroup -Identity $groupSiteMailNickName
 ```
-Retrieves a specific Office 365 Group based on the URL of its Modern SharePoint site
+Retrieves a specific Office 365 Group based on the mail nickname
 
 ### Example 5
 ```powershell


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Trying to add or get a term with an ampersand (&) errored. Using method NormalizeName to resolve.

Ref: https://msdn.microsoft.com/en-us/library/office/microsoft.sharepoint.taxonomy.taxonomyitem.normalizename.aspx
