### PR TITLE
Get limited items

### DIFF
--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -69,7 +69,11 @@ namespace SharePointPnP.PowerShell.Commands.Lists
 		[Parameter(Mandatory = false, HelpMessage = "The script block to run after every page request.", ParameterSetName = "ByQuery")]
 		public ScriptBlock ScriptBlock;
 
-		protected override void ExecuteCmdlet()
+        [Parameter(Mandatory = false, HelpMessage = "Limit the number of items to the set PageSize, otherwise it will return all results paged.", ParameterSetName = "AllItems")]
+        [Parameter(Mandatory = false, HelpMessage = "Limit the number of items to the set PageSize, otherwise it will return all results paged.", ParameterSetName = "ByQuery")]
+        public SwitchParameter LimitResults = false;
+
+        protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
 
@@ -112,7 +116,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
             else
             {
 				CamlQuery query = HasCamlQuery() ? new CamlQuery { ViewXml = Query } : CamlQuery.CreateAllItemsQuery();
-
+                
 				if (Fields != null)
                 {
                     var queryElement = XElement.Parse(query.ViewXml);
@@ -172,7 +176,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
 					}
 
 					query.ListItemCollectionPosition = listItems.ListItemCollectionPosition;
-                } while (query.ListItemCollectionPosition != null);
+                } while (query.ListItemCollectionPosition != null && !LimitResults);
             }
         }
 

--- a/Commands/Taxonomy/GetTerm.cs
+++ b/Commands/Taxonomy/GetTerm.cs
@@ -102,7 +102,9 @@ namespace SharePointPnP.PowerShell.Commands.Taxonomy
                 }
                 else
                 {
-                    term = termSet.Terms.GetByName(Identity.StringValue);
+                    var termName = TaxonomyItem.NormalizeName(ClientContext, Identity.StringValue);
+                    ClientContext.ExecuteQueryRetry();
+                    term = termSet.Terms.GetByName(termName.Value);
                 }
                 ClientContext.Load(term, RetrievalExpressions);
                 ClientContext.ExecuteQueryRetry();

--- a/Commands/Taxonomy/NewTerm.cs
+++ b/Commands/Taxonomy/NewTerm.cs
@@ -107,7 +107,9 @@ namespace SharePointPnP.PowerShell.Commands.Taxonomy
             {
                 Id = Guid.NewGuid();
             }
-            var term = termSet.CreateTerm(Name, Lcid, Id);
+            var termName = TaxonomyItem.NormalizeName(ClientContext,Name);
+            ClientContext.ExecuteQueryRetry();
+            var term = termSet.CreateTerm(termName.Value, Lcid, Id);
             ClientContext.Load(term);
             ClientContext.ExecuteQueryRetry();
             term.SetDescription(Description, Lcid);

--- a/Documentation/GetPnPListItem.md
+++ b/Documentation/GetPnPListItem.md
@@ -22,6 +22,7 @@ Get-PnPListItem -List <ListPipeBind>
                 [-Query <String>]
                 [-PageSize <Int>]
                 [-ScriptBlock <ScriptBlock>]
+                [-LimitResults [<SwitchParameter>]]
                 [-Web <WebPipeBind>]
 ```
 
@@ -31,6 +32,7 @@ Get-PnPListItem -List <ListPipeBind>
                 [-Fields <String[]>]
                 [-PageSize <Int>]
                 [-ScriptBlock <ScriptBlock>]
+                [-LimitResults [<SwitchParameter>]]
                 [-Web <WebPipeBind>]
 ```
 
@@ -44,6 +46,7 @@ Parameter|Type|Required|Description
 |List|ListPipeBind|True|The list to query|
 |Fields|String[]|False|The fields to retrieve. If not specified all fields will be loaded in the returned list object.|
 |Id|Int|False|The ID of the item to retrieve|
+|LimitResults|SwitchParameter|False|Limit the number of items to the set PageSize, otherwise it will return all results paged.|
 |PageSize|Int|False|The number of items to retrieve per page request.|
 |Query|String|False|The CAML query to execute against the list|
 |ScriptBlock|ScriptBlock|False|The script block to run after every page request.|

--- a/Documentation/GetPnPUnifiedGroup.md
+++ b/Documentation/GetPnPUnifiedGroup.md
@@ -3,12 +3,14 @@ Gets one Office 365 Group (aka Unified Group) or a list of Office 365 Groups
 ## Syntax
 ```powershell
 Get-PnPUnifiedGroup [-Identity <UnifiedGroupPipeBind>]
+                    [-ExcludeSiteUrl [<SwitchParameter>]]
 ```
 
 
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
+|ExcludeSiteUrl|SwitchParameter|False|Exclude fetching the site URL for Office 365 Groups. This speeds up large listings.|
 |Identity|UnifiedGroupPipeBind|False|The Identity of the Office 365 Group.|
 ## Examples
 
@@ -32,9 +34,9 @@ Retrieves a specific Office 365 Group based on its DisplayName
 
 ### Example 4
 ```powershell
-PS:> Get-PnPUnifiedGroup -Identity $groupSiteUrl
+PS:> Get-PnPUnifiedGroup -Identity $groupSiteMailNickName
 ```
-Retrieves a specific Office 365 Group based on the URL of its Modern SharePoint site
+Retrieves a specific Office 365 Group based on the mail nickname
 
 ### Example 5
 ```powershell


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
The `Get-PnPListItem` with `-PageSize` or using `<RowLimit>` in the `-Query` parameter didn't work. It would page the results, but not only return the limited count asked for. I added a new switch `-LimitResults` which will return only the first set of items specified in either `-PageSize` or `<RowLimit>`.


