### PR TITLE
Added the ExcludeContentTypesFromSyndication parameter to the Get-PnPProvisioningTemplate command

### DIFF
--- a/Commands/Provisioning/GetProvisioningTemplate.cs
+++ b/Commands/Provisioning/GetProvisioningTemplate.cs
@@ -73,6 +73,10 @@ PS:> Get-PnPProvisioningTemplate -Out NewTemplate.xml -ExtensibilityHandlers $ha
         Code = "PS:> Get-PnPProvisioningTemplate -Out template.pnp -ContentTypeGroups \"Group A\",\"Group B\"",
         Remarks = @"Extracts a provisioning template in Office Open XML from the current web, but only processes content types from the to given content type groups.",
         SortOrder = 12)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPProvisioningTemplate -Out template.pnp -ExcludeContentTypesFromSyndication",
+        Remarks = "Extracts a provisioning template in Office Open XML from the current web, excluding content types provisioned through content type syndication (content type hub), in order to prevent provisioning errors if the target also provision the content type using syndication.",
+        SortOrder = 13)]
     [CmdletRelatedLink(
         Text = "Encoding",
         Url = "https://msdn.microsoft.com/en-us/library/system.text.encoding_properties.aspx")]
@@ -161,6 +165,9 @@ PS:> Get-PnPProvisioningTemplate -Out NewTemplate.xml -ExtensibilityHandlers $ha
 
         [Parameter(Mandatory = false, HelpMessage = "Returns the template as an in-memory object, which is an instance of the ProvisioningTemplate type of the PnP Core Component. It cannot be used together with the -Out parameter.")]
         public SwitchParameter OutputInstance;
+
+        [Parameter(Mandatory = false, HelpMessage = "Specify whether or not content types issued from a content hub should be exported. By default, these content types are included.")]
+        public SwitchParameter ExcludeContentTypesFromSyndication;
 
         protected override void ExecuteCmdlet()
         {
@@ -354,6 +361,8 @@ PS:> Get-PnPProvisioningTemplate -Out NewTemplate.xml -ExtensibilityHandlers $ha
                     creationInformation.IncludeSiteCollectionTermGroup = true;
                 }
             }
+
+            creationInformation.IncludeContentTypesFromSyndication = !ExcludeContentTypesFromSyndication.ToBool();
 
             var template = SelectedWeb.GetProvisioningTemplate(creationInformation);
 

--- a/Documentation/GetPnPProvisioningTemplate.md
+++ b/Documentation/GetPnPProvisioningTemplate.md
@@ -11,8 +11,6 @@ Get-PnPProvisioningTemplate [-IncludeAllTermGroups [<SwitchParameter>]]
                             [-PersistPublishingFiles [<SwitchParameter>]]
                             [-IncludeNativePublishingFiles [<SwitchParameter>]]
                             [-SkipVersionCheck [<SwitchParameter>]]
-                            [-PersistMultiLanguageResources [<SwitchParameter>]]
-                            [-ResourceFilePrefix <String>]
                             [-Handlers <Handlers>]
                             [-ExcludeHandlers <Handlers>]
                             [-ExtensibilityHandlers <ExtensibilityHandler[]>]
@@ -24,6 +22,7 @@ Get-PnPProvisioningTemplate [-IncludeAllTermGroups [<SwitchParameter>]]
                             [-TemplateImagePreviewUrl <String>]
                             [-TemplateProperties <Hashtable>]
                             [-OutputInstance [<SwitchParameter>]]
+                            [-ExcludeContentTypesFromSyndication [<SwitchParameter>]]
                             [-Web <WebPipeBind>]
                             [-Out <String>]
                             [-Schema <XMLPnPSchemaVersion>]
@@ -35,6 +34,7 @@ Parameter|Type|Required|Description
 ---------|----|--------|-----------
 |ContentTypeGroups|String[]|False|Allows you to specify from which content type group(s) the content types should be included into the template.|
 |Encoding|Encoding|False|The encoding type of the XML file, Unicode is default|
+|ExcludeContentTypesFromSyndication|SwitchParameter|False|Specify whether or not content types issued from a content hub should be exported. By default, these content types are included.|
 |ExcludeHandlers|Handlers|False|Allows you to run all handlers, excluding the ones specified.|
 |ExtensibilityHandlers|ExtensibilityHandler[]|False|Allows you to specify ExtensbilityHandlers to execute while extracting a template.|
 |Force|SwitchParameter|False|Overwrites the output file if it exists.|
@@ -48,9 +48,7 @@ Parameter|Type|Required|Description
 |Out|String|False|Filename to write to, optionally including full path|
 |OutputInstance|SwitchParameter|False|Returns the template as an in-memory object, which is an instance of the ProvisioningTemplate type of the PnP Core Component. It cannot be used together with the -Out parameter.|
 |PersistBrandingFiles|SwitchParameter|False|If specified the files used for masterpages, sitelogo, alternate CSS and the files that make up the composed look will be saved.|
-|PersistMultiLanguageResources|SwitchParameter|False|If specified, resource values for applicable artifacts will be persisted to a resource file|
 |PersistPublishingFiles|SwitchParameter|False|If specified the files used for the publishing feature will be saved.|
-|ResourceFilePrefix|String|False|If specified, resource files will be saved with the specified prefix instead of using the template name specified. If no template name is specified the files will be called PnP-Resources.<language>.resx. See examples for more info.|
 |Schema|XMLPnPSchemaVersion|False|The schema of the output to use, defaults to the latest schema|
 |SkipVersionCheck|SwitchParameter|False|During extraction the version of the server will be checked for certain actions. If you specify this switch, this check will be skipped.|
 |TemplateDisplayName|String|False|It can be used to specify the DisplayName of the template file that will be extracted.|
@@ -110,26 +108,14 @@ PS:> $handler2 = New-PnPExtensibilityHandlerObject -Assembly Contoso.Core.Handle
 PS:> Get-PnPProvisioningTemplate -Out NewTemplate.xml -ExtensibilityHandlers $handler1,$handler2
 ```
 This will create two new ExtensibilityHandler objects that are run during extraction of the template
-Only supported on SP2016 and SP Online
-### Example 9
-```powershell
-PS:> Get-PnPProvisioningTemplate -Out template.pnp -PersistMultiLanguageResources
-```
-Extracts a provisioning template in Office Open XML from the current web, and for supported artifacts it will create a resource file for each supported language (based upon the language settings of the current web). The generated resource files will be named after the value specified in the Out parameter. For instance if the Out parameter is specified as -Out 'template.xml' the generated resource file will be called 'template.en-US.resx'.
-Only supported on SP2016 and SP Online
-### Example 10
-```powershell
-PS:> Get-PnPProvisioningTemplate -Out template.pnp -PersistMultiLanguageResources -ResourceFilePrefix MyResources
-```
-Extracts a provisioning template in Office Open XML from the current web, and for supported artifacts it will create a resource file for each supported language (based upon the language settings of the current web). The generated resource files will be named 'MyResources.en-US.resx' etc.
 
-### Example 11
+### Example 9
 ```powershell
 PS:> $template = Get-PnPProvisioningTemplate -OutputInstance
 ```
 Extracts an instance of a provisioning template object from the current web. This syntax cannot be used together with the -Out parameter, but it can be used together with any other supported parameters.
 
-### Example 12
+### Example 10
 ```powershell
 PS:> Get-PnPProvisioningTemplate -Out template.pnp -ContentTypeGroups "Group A","Group B"
 ```


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Continuation of the PR https://github.com/SharePoint/PnP-Sites-Core/pull/1222, related to the https://github.com/SharePoint/PnP-Sites-Core/issues/1208 issue.

## What is in this Pull Request ? ##
Content types provision fails if the same content type already exists in the target and is read only. This is the case when the CT is provisioned in the target through content type syndication.
This PR includes a new switch parameter to the Get-PnPProvisioningTemplate command, that allows excluding these CTs. 
PnP-Sites-Core components has already been updated to support this scenario.