### PR TITLE
added recycling options to remove commands

### DIFF
--- a/Commands/Files/RemoveFile.cs
+++ b/Commands/Files/RemoveFile.cs
@@ -17,6 +17,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
         Code = @"PS:>Remove-PnPFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor",
         SortOrder = 2,
         Remarks = @"Removes the file company.spcolor")]
+    [CmdletExample(
+        Code = @"PS:>Remove-PnPFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor -Recycle",
+        SortOrder = 2,
+        Remarks = @"Removes the file company.spcolor and saves it to the Recycle Bin")]
 
     public class RemoveFile : PnPWebCmdlet
     {
@@ -25,6 +29,9 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = "SITE", HelpMessage = "Site relative URL to the file")]
         public string SiteRelativeUrl = string.Empty;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Recycle;
 
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
@@ -44,7 +51,14 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
             if (Force || ShouldContinue(string.Format(Resources.Delete0, file.Name), Resources.Confirm))
             {
-                file.DeleteObject();
+                if (Recycle)
+                {
+                    file.Recycle();
+                }
+                else
+                {
+                    file.DeleteObject();
+                }
 
                 ClientContext.ExecuteQueryRetry();
             }

--- a/Commands/Files/RemoveFolder.cs
+++ b/Commands/Files/RemoveFolder.cs
@@ -13,6 +13,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
         Code = @"PS:> Remove-PnPFolder -Name NewFolder -Folder _catalogs/masterpage",
         SortOrder = 1,
         Remarks = @"Removes the folder 'NewFolder' from '_catalogsmasterpage'")]
+    [CmdletExample(
+        Code = @"PS:> Remove-PnPFolder -Name NewFolder -Folder _catalogs/masterpage -Recycle",
+        SortOrder = 1,
+        Remarks = @"Removes the folder 'NewFolder' from '_catalogsmasterpage' and is saved in the Recycle Bin")]
     public class RemoveFolder : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "The folder name")]
@@ -20,6 +24,9 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         [Parameter(Mandatory = true, HelpMessage = "The parent folder in the site")]
         public string Folder = string.Empty;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Recycle;
 
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
@@ -34,7 +41,14 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
             if (Force || ShouldContinue(string.Format(Resources.Delete0, folder.Name), Resources.Confirm))
             {
-                folder.DeleteObject();
+                if (Recycle)
+                {
+                    folder.Recycle();
+                }
+                else
+                {
+                    folder.DeleteObject();
+                }
 
                 ClientContext.ExecuteQueryRetry();
             }

--- a/Commands/Lists/RemoveList.cs
+++ b/Commands/Lists/RemoveList.cs
@@ -16,10 +16,17 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Code = "PS:> Remove-PnPList -Title Announcements -Force",
         SortOrder = 2,
         Remarks = @"Removes the list named 'Announcements' without asking for confirmation.")]
+    [CmdletExample(
+        Code = "PS:> Remove-PnPList -Title Announcements -Recycle",
+        SortOrder = 2,
+        Remarks = @"Removes the list named 'Announcements' and saves to the Recycle Bin")]
     public class RemoveList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID or Title of the list.")]
         public ListPipeBind Identity = new ListPipeBind();
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Recycle;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
         public SwitchParameter Force;
@@ -32,7 +39,14 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 {
                     if (Force || ShouldContinue(Properties.Resources.RemoveList, Properties.Resources.Confirm))
                     {
-                        list.DeleteObject();
+                        if (Recycle)
+                        {
+                            list.Recycle();
+                        }
+                        else
+                        {
+                            list.DeleteObject();
+                        }
                         ClientContext.ExecuteQueryRetry();
                     }
                 }

--- a/Commands/Lists/RemoveListItem.cs
+++ b/Commands/Lists/RemoveListItem.cs
@@ -12,6 +12,10 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Code = @"PS:> Remove-PnPListItem -List ""Demo List"" -Identity ""1"" -Force",
         SortOrder = 1,
         Remarks = @"Removes the listitem with id ""1"" from the ""Demo List"" list.")]
+    [CmdletExample(
+        Code = @"PS:> Remove-PnPListItem -List ""Demo List"" -Identity ""1"" -Force -Recycle",
+        SortOrder = 1,
+        Remarks = @"Removes the listitem with id ""1"" from the ""Demo List"" list and saves it in the Recycle Bin.")]
     public class RemoveListItem : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]
@@ -19,6 +23,9 @@ namespace SharePointPnP.PowerShell.Commands.Lists
 
         [Parameter(Mandatory = true, HelpMessage = "The ID of the listitem, or actual ListItem object")]
         public ListItemPipeBind Identity;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Recycle;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
         public SwitchParameter Force;
@@ -31,7 +38,14 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 var item = Identity.GetListItem(list);
                 if (Force || ShouldContinue(string.Format(Properties.Resources.RemoveListItemWithId0,item.Id), Properties.Resources.Confirm))
                 {
-                    item.DeleteObject();
+                    if (Recycle)
+                    {
+                        item.Recycle();
+                    }
+                    else
+                    {
+                        item.DeleteObject();
+                    }
                     ClientContext.ExecuteQueryRetry();
                 }
             }

--- a/Documentation/RemovePnPFile.md
+++ b/Documentation/RemovePnPFile.md
@@ -3,6 +3,7 @@ Removes a file.
 ## Syntax
 ```powershell
 Remove-PnPFile -ServerRelativeUrl <String>
+               [-Recycle [<SwitchParameter>]]
                [-Force [<SwitchParameter>]]
                [-Web <WebPipeBind>]
 ```
@@ -10,6 +11,7 @@ Remove-PnPFile -ServerRelativeUrl <String>
 
 ```powershell
 Remove-PnPFile -SiteRelativeUrl <String>
+               [-Recycle [<SwitchParameter>]]
                [-Force [<SwitchParameter>]]
                [-Web <WebPipeBind>]
 ```
@@ -21,6 +23,7 @@ Parameter|Type|Required|Description
 |ServerRelativeUrl|String|True|Server relative URL to the file|
 |SiteRelativeUrl|String|True|Site relative URL to the file|
 |Force|SwitchParameter|False||
+|Recycle|SwitchParameter|False||
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ## Examples
 
@@ -35,3 +38,9 @@ Removes the file company.spcolor
 PS:>Remove-PnPFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor
 ```
 Removes the file company.spcolor
+
+### Example 3
+```powershell
+PS:>Remove-PnPFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor -Recycle
+```
+Removes the file company.spcolor and saves it to the Recycle Bin

--- a/Documentation/RemovePnPFolder.md
+++ b/Documentation/RemovePnPFolder.md
@@ -4,6 +4,7 @@ Deletes a folder within a parent folder
 ```powershell
 Remove-PnPFolder -Name <String>
                  -Folder <String>
+                 [-Recycle [<SwitchParameter>]]
                  [-Force [<SwitchParameter>]]
                  [-Web <WebPipeBind>]
 ```
@@ -15,6 +16,7 @@ Parameter|Type|Required|Description
 |Folder|String|True|The parent folder in the site|
 |Name|String|True|The folder name|
 |Force|SwitchParameter|False||
+|Recycle|SwitchParameter|False||
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ## Examples
 
@@ -23,3 +25,9 @@ Parameter|Type|Required|Description
 PS:> Remove-PnPFolder -Name NewFolder -Folder _catalogs/masterpage
 ```
 Removes the folder 'NewFolder' from '_catalogsmasterpage'
+
+### Example 2
+```powershell
+PS:> Remove-PnPFolder -Name NewFolder -Folder _catalogs/masterpage -Recycle
+```
+Removes the folder 'NewFolder' from '_catalogsmasterpage' and is saved in the Recycle Bin

--- a/Documentation/RemovePnPList.md
+++ b/Documentation/RemovePnPList.md
@@ -3,6 +3,7 @@ Deletes a list
 ## Syntax
 ```powershell
 Remove-PnPList -Identity <ListPipeBind>
+               [-Recycle [<SwitchParameter>]]
                [-Force [<SwitchParameter>]]
                [-Web <WebPipeBind>]
 ```
@@ -13,6 +14,7 @@ Parameter|Type|Required|Description
 ---------|----|--------|-----------
 |Identity|ListPipeBind|True|The ID or Title of the list.|
 |Force|SwitchParameter|False|Specifying the Force parameter will skip the confirmation question.|
+|Recycle|SwitchParameter|False||
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ## Examples
 
@@ -27,3 +29,9 @@ Removes the list named 'Announcements'. Asks for confirmation.
 PS:> Remove-PnPList -Title Announcements -Force
 ```
 Removes the list named 'Announcements' without asking for confirmation.
+
+### Example 3
+```powershell
+PS:> Remove-PnPList -Title Announcements -Recycle
+```
+Removes the list named 'Announcements' and saves to the Recycle Bin

--- a/Documentation/RemovePnPListItem.md
+++ b/Documentation/RemovePnPListItem.md
@@ -4,6 +4,7 @@ Deletes an item from a list
 ```powershell
 Remove-PnPListItem -Identity <ListItemPipeBind>
                    -List <ListPipeBind>
+                   [-Recycle [<SwitchParameter>]]
                    [-Force [<SwitchParameter>]]
                    [-Web <WebPipeBind>]
 ```
@@ -15,6 +16,7 @@ Parameter|Type|Required|Description
 |Identity|ListItemPipeBind|True|The ID of the listitem, or actual ListItem object|
 |List|ListPipeBind|True|The ID, Title or Url of the list.|
 |Force|SwitchParameter|False|Specifying the Force parameter will skip the confirmation question.|
+|Recycle|SwitchParameter|False||
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ## Examples
 
@@ -23,3 +25,9 @@ Parameter|Type|Required|Description
 PS:> Remove-PnPListItem -List "Demo List" -Identity "1" -Force
 ```
 Removes the listitem with id "1" from the "Demo List" list.
+
+### Example 2
+```powershell
+PS:> Remove-PnPListItem -List "Demo List" -Identity "1" -Force -Recycle
+```
+Removes the listitem with id "1" from the "Demo List" list and saves it in the Recycle Bin.


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
New Recycle switches on `Remove-PnPListItem`, `Remove-PnPList1`, `Remove-PnPFile` and `Remove-PnPFolder`

Should deprecate `MoveListItemToRecycleBin`?
