### PR TITLE
Improve get tenant site to support all site types and use newer CSOM API

### DIFF
--- a/Commands/Admin/GetTenantSite.cs
+++ b/Commands/Admin/GetTenantSite.cs
@@ -1,6 +1,7 @@
 ﻿#if !ONPREMISES
 using System.Linq;
 using System.Management.Automation;
+using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base;
@@ -11,14 +12,17 @@ namespace SharePointPnP.PowerShell.Commands
 {
 
     [Cmdlet(VerbsCommon.Get, "PnPTenantSite", SupportsShouldProcess = true)]
-    [CmdletHelp(@"Office365 only: Uses the tenant API to retrieve site information.", 
+    [CmdletHelp(@"Office365 only: Uses the tenant API to retrieve site information.",
         Category = CmdletHelpCategory.TenantAdmin,
         OutputType = typeof(Microsoft.Online.SharePoint.TenantAdministration.SiteProperties),
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.online.sharepoint.tenantadministration.siteproperties.aspx")]
     [CmdletExample(Code = @"PS:> Get-PnPTenantSite", Remarks = "Returns all site collections", SortOrder = 1)]
-    [CmdletExample(Code = @"PS:> Get-PnPTenantSite -Url http://tenant.sharepoint.com/sites/projects", Remarks = "Returns information about the project site.",SortOrder = 2)]
+    [CmdletExample(Code = @"PS:> Get-PnPTenantSite -Url http://tenant.sharepoint.com/sites/projects", Remarks = "Returns information about the project site.", SortOrder = 2)]
     [CmdletExample(Code = @"PS:> Get-PnPTenantSite -Detailed", Remarks = "Returns all sites with the full details of these sites", SortOrder = 3)]
     [CmdletExample(Code = @"PS:> Get-PnPTenantSite -IncludeOneDriveSites", Remarks = "Returns all sites including all OneDrive 4 Business sites", SortOrder = 4)]
+    [CmdletExample(Code = @"PS:> Get-PnPTenantSite -IncludeOneDriveSites -Filter ""Url -like '-my.sharepoint.com/personal/'""", Remarks = "Returns all OneDrive for Business sites.", SortOrder = 5)]
+    [CmdletExample(Code = @"PS:> Get-PnPTenantSite -WebTemplate SITEPAGEPUBLISHING#0", Remarks = "Returns all Communication sites", SortOrder = 6)]
+    [CmdletExample(Code = @"PS:> Get-PnPTenantSite -Filter ""Url -like 'sales'"" ", Remarks = "Returns all sites including 'sales' in the url.", SortOrder = 7)]
     public class GetTenantSite : PnPAdminCmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "The URL of the site", Position = 0, ValueFromPipeline = true)]
@@ -31,12 +35,18 @@ namespace SharePointPnP.PowerShell.Commands
         [Parameter(Mandatory = false, HelpMessage = "By default, not all returned attributes are populated. This switch populates all attributes. It can take several seconds to run. Without this, some attributes will show default values that may not be correct.")]
         public SwitchParameter Detailed;
 
-        [Parameter(Mandatory = false, HelpMessage = "By default, the OneDrives are not returned. This switch includes all OneDrives. This can take some extra time to run")]
+        [Parameter(Mandatory = false, HelpMessage = "By default, the OneDrives are not returned. This switch includes all OneDrives.")]
         public SwitchParameter IncludeOneDriveSites;
 
-        
+
         [Parameter(Mandatory = false, HelpMessage = "When the switch IncludeOneDriveSites is used, this switch ignores the question shown that the command can take a long time to execute")]
         public SwitchParameter Force;
+
+        [Parameter(Mandatory = false, HelpMessage = "Limit results to a specific web template name.")]
+        public string WebTemplate;
+
+        [Parameter(Mandatory = false, HelpMessage = "When the switch IncludeOneDriveSites is used, this switch ignores the question shown that the command can take a long time to execute")]
+        public string Filter;
 
         protected override void ExecuteCmdlet()
         {
@@ -55,10 +65,17 @@ namespace SharePointPnP.PowerShell.Commands
                 }
                 else
                 {
+                    SPOSitePropertiesEnumerableFilter filter = new SPOSitePropertiesEnumerableFilter()
+                    {
+                        IncludePersonalSite = IncludeOneDriveSites.IsPresent ? PersonalSiteFilter.Include : PersonalSiteFilter.UseServerDefault,
+                        StartIndex = null,
+                        IncludeDetail = true,
+                        Template = WebTemplate,
+                        Filter = Filter
+                    };
 
+                    var list = Tenant.GetSitePropertiesFromSharePointByFilters(filter);
 
-                    var list = Tenant.GetSiteProperties(0, Detailed);
-                  
                     Tenant.Context.Load(list);
                     Tenant.Context.ExecuteQueryRetry();
                     var siteProperties = list.ToList();
@@ -75,24 +92,6 @@ namespace SharePointPnP.PowerShell.Commands
                         returnedEntries = nextList.Count;
                     }
 
-                    
-                    
-                    if (IncludeOneDriveSites)
-                    {
-                        if (Force || ShouldContinue(Resources.GetTenantSite_ExecuteCmdlet_This_request_can_take_a_long_time_to_execute__Continue_, Resources.Confirm))
-                        {
-                            var onedriveSites = Tenant.GetOneDriveSiteCollections();
-
-                            var personalUrl = ClientContext.Url.ToLower().Replace("-admin", "-my");
-                            foreach (var site in onedriveSites)
-                            {
-                                var siteprops = Tenant.GetSitePropertiesByUrl($"{personalUrl.TrimEnd('/')}/{site.Url.Trim('/')}", Detailed);
-                                ClientContext.Load(siteprops);
-                                ClientContext.ExecuteQueryRetry();
-                                siteProperties.Add(siteprops);
-                            }
-                        }
-                    }
                     if (Template != null)
                     {
                         WriteObject(siteProperties.Where(t => t.Template == Template).OrderBy(x => x.Url), true);

--- a/Commands/Admin/GetTenantSite.cs
+++ b/Commands/Admin/GetTenantSite.cs
@@ -37,14 +37,13 @@ namespace SharePointPnP.PowerShell.Commands
         [Parameter(Mandatory = false, HelpMessage = "By default, the OneDrives are not returned. This switch includes all OneDrives.")]
         public SwitchParameter IncludeOneDriveSites;
 
-
         [Parameter(Mandatory = false, HelpMessage = "When the switch IncludeOneDriveSites is used, this switch ignores the question shown that the command can take a long time to execute")]
         public SwitchParameter Force;
 
         [Parameter(Mandatory = false, HelpMessage = "Limit results to a specific web template name.")]
         public string WebTemplate;
 
-        [Parameter(Mandatory = false, HelpMessage = "When the switch IncludeOneDriveSites is used, this switch ignores the question shown that the command can take a long time to execute")]
+        [Parameter(Mandatory = false, HelpMessage = "Specifies the script block of the server-side filter to apply. See https://technet.microsoft.com/en-us/library/fp161380.aspx")]
         public string Filter;
 
         protected override void ExecuteCmdlet()
@@ -70,7 +69,7 @@ namespace SharePointPnP.PowerShell.Commands
                         StartIndex = null,
                         IncludeDetail = true,
                         Template = WebTemplate,
-                        Filter = Filter
+                        Filter = Filter,
                     };
 
                     var list = Tenant.GetSitePropertiesFromSharePointByFilters(filter);

--- a/Commands/Admin/GetTenantSite.cs
+++ b/Commands/Admin/GetTenantSite.cs
@@ -6,7 +6,6 @@ using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base;
 using SharePointPnP.PowerShell.Commands.Enums;
-using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
 
 namespace SharePointPnP.PowerShell.Commands
 {
@@ -79,18 +78,6 @@ namespace SharePointPnP.PowerShell.Commands
                     Tenant.Context.Load(list);
                     Tenant.Context.ExecuteQueryRetry();
                     var siteProperties = list.ToList();
-                    var returnedEntries = list.Count;
-
-                    var startIndex = 0;
-                    while (returnedEntries > 299)
-                    {
-                        startIndex = startIndex + 300;
-                        var nextList = Tenant.GetSiteProperties(startIndex, Detailed);
-                        Tenant.Context.Load(nextList);
-                        Tenant.Context.ExecuteQueryRetry();
-                        siteProperties.AddRange(nextList);
-                        returnedEntries = nextList.Count;
-                    }
 
                     if (Template != null)
                     {


### PR DESCRIPTION
## Type ##
- [x] Improvement

## What is in this Pull Request ? ##
Changed the cmdlet to use GetSitePropertiesFromSharePointByFilters, which allows retrieval of all site types.
Added option to filter by WebTemplate or Filter param, which supports Url wildcard at least. Could not find documentation on what other filters are possible,