### PR TITLE
Added exception handling get pn p file not found

### DIFF
--- a/Commands/Files/GetFile.cs
+++ b/Commands/Files/GetFile.cs
@@ -121,6 +121,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
                         var record = Utilities.PSObjectConverter.ConvertListItem(file.ListItemAllFields);
                         WriteObject(record);
                     }
+                    else
+                    {
+                        throw new ArgumentException($"No file found with the provided Url {serverRelativeUrl}", "Url");
+                    }
                     break;
                 case URLASSTRING:
                     WriteObject(SelectedWeb.GetFileAsString(serverRelativeUrl));

--- a/Commands/Files/GetFile.cs
+++ b/Commands/Files/GetFile.cs
@@ -60,8 +60,11 @@ namespace SharePointPnP.PowerShell.Commands.Files
         [Parameter(Mandatory = true, ParameterSetName = URLTOPATH)]
         public SwitchParameter AsFile;
 
-        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM)]
+        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM, HelpMessage = "Returns the file as a listitem showing all its properties")]
         public SwitchParameter AsListItem;
+
+        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM, HelpMessage = "If provided in combination with -AsListItem, a Sytem.ArgumentException will be thrown if the file specified in the -Url argument does not exist. Otherwise it will return nothing instead.")]
+        public SwitchParameter ThrowExceptionIfFileNotFound;
 
         [Parameter(Mandatory = false, ParameterSetName = URLASSTRING, HelpMessage = "Retrieve the file contents as a string")]
         public SwitchParameter AsString;
@@ -123,7 +126,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
                     }
                     else
                     {
-                        throw new ArgumentException($"No file found with the provided Url {serverRelativeUrl}", "Url");
+                        if (ThrowExceptionIfFileNotFound)
+                        {
+                            throw new ArgumentException($"No file found with the provided Url {serverRelativeUrl}", "Url");
+                        }
                     }
                     break;
                 case URLASSTRING:

--- a/Commands/Files/GetFile.cs
+++ b/Commands/Files/GetFile.cs
@@ -118,7 +118,8 @@ namespace SharePointPnP.PowerShell.Commands.Files
                     ClientContext.ExecuteQueryRetry();
                     if (file.Exists)
                     {
-                        WriteObject(file.ListItemAllFields);
+                        var record = Utilities.PSObjectConverter.ConvertListItem(file.ListItemAllFields);
+                        WriteObject(record);
                     }
                     break;
                 case URLASSTRING:

--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -92,28 +92,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 }
                 ClientContext.ExecuteQueryRetry();
 
-                // Some fields require special handling to make their contents readable, do that here
-                var record = new PSObject();
-                foreach (var field in listItem.FieldValues)
-                {
-                    switch(field.Value?.GetType().ToString())
-                    {
-                        case "Microsoft.SharePoint.Client.FieldUserValue":
-                            var user = (FieldUserValue)field.Value;
-                            record.Properties.Add(new PSVariableProperty(new PSVariable(field.Key, $"{user.LookupId};#{user.LookupValue} {user.Email}")));
-                            break;
-
-                        case "Microsoft.SharePoint.Client.FieldLookupValue":
-                            var lookup = (FieldLookupValue)field.Value;
-                            record.Properties.Add(new PSVariableProperty(new PSVariable(field.Key, $"{lookup.LookupId};#{lookup.LookupValue}")));
-                            break;
-
-                        default:
-                            record.Properties.Add(new PSVariableProperty(new PSVariable(field.Key, field.Value)));
-                            break;
-                    }
-                }
-                
+                var record = Utilities.PSObjectConverter.ConvertListItem(listItem);
                 WriteObject(record);
             }
             else if (HasUniqueId())

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -605,6 +605,7 @@
     <Compile Include="UserProfiles\SetUserProfileProperty.cs" />
     <Compile Include="Utilities\DynamicLinq.cs" />
     <Compile Include="Utilities\HttpHelper.cs" />
+    <Compile Include="Utilities\PSObjectConverter.cs" />
     <Compile Include="WebParts\GetWebPartProperty.cs" />
     <Compile Include="Branding\RemoveJavaScriptLink.cs" />
     <Compile Include="Branding\AddJavaScriptLink.cs" />

--- a/Commands/Utilities/PSObjectConverter.cs
+++ b/Commands/Utilities/PSObjectConverter.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.SharePoint.Client;
+using System.Management.Automation;
+
+namespace SharePointPnP.PowerShell.Commands.Utilities
+{
+    /// <summary>
+    /// Utilitity class to aid in converting model classes to PSObject classes suitable to be output in PowerShell
+    /// </summary>
+    public static class PSObjectConverter
+    {
+        /// <summary>
+        /// Takes a ListItem and converts its properties to a PSObject
+        /// </summary>
+        /// <param name="listItem">ListItem to take its properties from</param>
+        /// <returns>PSObject which can be used to output the properties</returns>
+        public static PSObject ConvertListItem(ListItem listItem)
+        {
+            var record = new PSObject();
+            foreach (var field in listItem.FieldValues)
+            {
+                switch (field.Value?.GetType().ToString())
+                {
+                    // User picker
+                    case "Microsoft.SharePoint.Client.FieldUserValue":
+                        var user = (FieldUserValue)field.Value;
+                        record.Properties.Add(new PSVariableProperty(new PSVariable(field.Key, $"{user.LookupId};#{user.LookupValue} {user.Email}")));
+                        break;
+
+                    // Lookup field
+                    case "Microsoft.SharePoint.Client.FieldLookupValue":
+                        var lookup = (FieldLookupValue)field.Value;
+                        record.Properties.Add(new PSVariableProperty(new PSVariable(field.Key, $"{lookup.LookupId};#{lookup.LookupValue}")));
+                        break;
+
+                    // Any other field
+                    default:
+                        record.Properties.Add(new PSVariableProperty(new PSVariable(field.Key, field.Value)));
+                        break;
+                }
+            }
+
+            return record;
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
When using Get-PnPFile -AsListItem with an Url that does not lead to a file that actually exists, no output would be given. This fix ensures that a proper ArgumentException gets thrown so it becomes clear to the end user that there's no output due to the Url being wrong.

Added -ThrowExceptionIfFileNotFound argument as requested in previous pull https://github.com/SharePoint/PnP-PowerShell/pull/946