### PR TITLE
Added Get-PnPFile -AsListItem -ThrowExceptionIfFileNotFound flag

### DIFF
--- a/Commands/Files/GetFile.cs
+++ b/Commands/Files/GetFile.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Management.Automation;
+﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.Core.Utilities;
-using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
 
 namespace SharePointPnP.PowerShell.Commands.Files
 {
@@ -60,8 +58,11 @@ namespace SharePointPnP.PowerShell.Commands.Files
         [Parameter(Mandatory = true, ParameterSetName = URLTOPATH)]
         public SwitchParameter AsFile;
 
-        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM)]
+        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM, HelpMessage = "Returns the file as a listitem showing all its properties")]
         public SwitchParameter AsListItem;
+
+        [Parameter(Mandatory = false, ParameterSetName = URLASLISTITEM, HelpMessage = "If provided in combination with -AsListItem, a Sytem.ArgumentException will be thrown if the file specified in the -Url argument does not exist. Otherwise it will return nothing instead.")]
+        public SwitchParameter ThrowExceptionIfFileNotFound;
 
         [Parameter(Mandatory = false, ParameterSetName = URLASSTRING, HelpMessage = "Retrieve the file contents as a string")]
         public SwitchParameter AsString;
@@ -119,6 +120,13 @@ namespace SharePointPnP.PowerShell.Commands.Files
                     if (file.Exists)
                     {
                         WriteObject(file.ListItemAllFields);
+                    }
+                    else
+                    {
+                        if (ThrowExceptionIfFileNotFound)
+                        {
+                            throw new PSArgumentException($"No file found with the provided Url {serverRelativeUrl}", "Url");
+                        }
                     }
                     break;
                 case URLASSTRING:


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/1007

## What is in this Pull Request ? ##
Added -ThrowExceptionIfFileNotFound flag to Get-PnPFile -AsListItem which will throw a PSArgumentException if the file provided can not be found. If the flag is not provided, it will return an empty response to allow backwards compatibility.