### PR TITLE
Adding -IgnoreSslErrors option to Connect-PnPOnline

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -9,6 +9,7 @@ using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core;
 using SharePointPnP.PowerShell.Commands.Provider;
 using File = System.IO.File;
+using System.Net;
 #if !ONPREMISES
 using Microsoft.SharePoint.Client.CompliancePolicy;
 #endif
@@ -151,6 +152,9 @@ dir",
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets, HelpMessage = "Should we skip the check if this site is the Tenant admin site. Default is false")]
         public SwitchParameter SkipTenantAdminCheck;
 
+        [Parameter(Mandatory = false, HelpMessage = "Ignores any SSL errors. To be used i.e. when connecting to a SharePoint farm using self signed certificates or using a certificate authority not trusted by this machine.")]
+        public SwitchParameter IgnoreSslErrors;
+
 #if ONPREMISES
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_HIGHTRUST, HelpMessage = "The path to the private key certificate (.pfx) to use for the High Trust connection")]
         public string HighTrustCertificatePath;
@@ -164,6 +168,11 @@ dir",
 
         protected override void ProcessRecord()
         {
+            if (IgnoreSslErrors)
+            {
+                ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
+            }
+
             PSCredential creds = null;
             if (Credentials != null)
             {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/964

## What is in this Pull Request ? ##
Added -IgnoreSslErrors option to Connect-PnPOnline to ignore any kind of SSL related issues when connecting to a SharePoint farm using i.e. self signed certs