### PR TITLE
Added support for -Include in Get-PnPSubWebs

### DIFF
--- a/Commands/Web/GetSubwebs.cs
+++ b/Commands/Web/GetSubwebs.cs
@@ -1,18 +1,19 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
-using web = Microsoft.SharePoint.Client.Web;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using System;
 
 namespace SharePointPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "PnPSubWebs")]
     [CmdletHelp("Returns the subwebs of the current web", 
         Category = CmdletHelpCategory.Webs,
-        OutputType = typeof(List<web>),
+        OutputType = typeof(WebCollection),
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.web.aspx")]
-    public class GetSubWebs : PnPWebCmdlet
+    public class GetSubWebs : PnPWebRetrievalsCmdlet<WebCollection>
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0)]
         public WebPipeBind Identity;
@@ -22,35 +23,36 @@ namespace SharePointPnP.PowerShell.Commands
 
         protected override void ExecuteCmdlet()
         {
-            var webs = SelectedWeb.Context.LoadQuery(SelectedWeb.Webs);
-            SelectedWeb.Context.ExecuteQueryRetry();
+            DefaultRetrievalExpressions = new Expression<Func<WebCollection, object>>[] { wc => wc.Include(w => w.Id, w => w.Url, w => w.Title, w => w.ServerRelativeUrl) };
+
+            SelectedWeb.Webs.EnsureProperties(RetrievalExpressions);
             if (!Recurse)
             {
-                WriteObject(webs, true);
+                WriteObject(SelectedWeb.Webs, true);
             }
-            else
-            {
-                var subwebs = new List<web>();
-                subwebs.AddRange(webs);
-                foreach (var subweb in webs)
-                {
-                    subwebs.AddRange(GetSubWebsInternal(subweb));
-                }
-                WriteObject(subwebs, true);
-            }
+        //    else
+        //    {
+        //        var subwebs = new List<web>();
+        //        subwebs.AddRange(webs);
+        //        foreach (var subweb in webs)
+        //        {
+        //            subwebs.AddRange(GetSubWebsInternal(subweb));
+        //        }
+        //        WriteObject(subwebs, true);
+        //    }
         }
 
-        private List<web> GetSubWebsInternal(web subweb)
-        {
-            var subwebs = new List<web>();
-            var webs = subweb.Context.LoadQuery(subweb.Webs);
-            subweb.Context.ExecuteQueryRetry();
-            subwebs.AddRange(webs);
-            foreach (var sw in webs)
-            {
-                subwebs.AddRange(GetSubWebsInternal(sw));
-            }
-            return subwebs;
-        }
+        //private List<web> GetSubWebsInternal(web subweb)
+        //{
+        //    var subwebs = new List<web>();
+        //    var webs = subweb.Context.LoadQuery(subweb.Webs);
+        //    subweb.Context.ExecuteQueryRetry();
+        //    subwebs.AddRange(webs);
+        //    foreach (var sw in webs)
+        //    {
+        //        subwebs.AddRange(GetSubWebsInternal(sw));
+        //    }
+        //    return subwebs;
+        //}
     }
 }

--- a/Commands/Web/GetSubwebs.cs
+++ b/Commands/Web/GetSubwebs.cs
@@ -5,52 +5,84 @@ using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System;
+using SharePointPnP.PowerShell.Commands.Extensions;
 
 namespace SharePointPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "PnPSubWebs")]
     [CmdletHelp("Returns the subwebs of the current web", 
         Category = CmdletHelpCategory.Webs,
-        OutputType = typeof(WebCollection),
+        OutputType = typeof(Web),
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.web.aspx")]
-    public class GetSubWebs : PnPWebRetrievalsCmdlet<WebCollection>
+    [CmdletExample(
+        Code = @"PS:> Get-PnPSubWebs",
+        Remarks = "Retrieves all subsites of the current context returning the Id, Url, Title and ServerRelativeUrl of each subsite in the output",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPSubWebs -Recurse",
+        Remarks = "Retrieves all subsites of the current context and all of their nested child subsites returning the Id, Url, Title and ServerRelativeUrl of each subsite in the output",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPSubWebs -Recurse -Include ""WebTemplate"",""Description"" | Select ServerRelativeUrl, WebTemplate, Description",
+        Remarks = "Retrieves all subsites of the current context and shows the ServerRelativeUrl, WebTemplate and Description properties in the resulting output",
+        SortOrder = 3)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPSubWebs -Identity Team1 -Recurse",
+        Remarks = "Retrieves all subsites of the subsite Team1 and all of its nested child subsites returning the Id, Url, Title and ServerRelativeUrl of each subsite in the output",
+        SortOrder = 4)]
+    public class GetSubWebs : PnPWebRetrievalsCmdlet<Web>
     {
-        [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0)]
+        [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0, HelpMessage = "If provided, only the subsite with the provided Id, GUID or the Web instance will be returned")]
         public WebPipeBind Identity;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If provided, recursion through all subsites and their childs will take place to return them as well")]
         public SwitchParameter Recurse;
 
         protected override void ExecuteCmdlet()
         {
-            DefaultRetrievalExpressions = new Expression<Func<WebCollection, object>>[] { wc => wc.Include(w => w.Id, w => w.Url, w => w.Title, w => w.ServerRelativeUrl) };
+            DefaultRetrievalExpressions = new Expression<Func<Web, object>>[] { w => w.Id, w => w.Url, w => w.Title, w => w.ServerRelativeUrl };
 
-            SelectedWeb.Webs.EnsureProperties(RetrievalExpressions);
-            if (!Recurse)
+            Web parentWeb = SelectedWeb;
+            if (Identity != null)
             {
-                WriteObject(SelectedWeb.Webs, true);
-            }
-            else
-            {
-                var subwebs = new List<Web>();
-                subwebs.AddRange(SelectedWeb.Webs);
-                foreach (var subweb in SelectedWeb.Webs)
+                if (Identity.Id != Guid.Empty)
                 {
-                    subwebs.AddRange(GetSubWebsInternal(subweb));
+                    parentWeb = parentWeb.GetWebById(Identity.Id);
                 }
-                WriteObject(subwebs, true);
+                else if (Identity.Web != null)
+                {
+                    parentWeb = Identity.Web;
+                }
+                else if (Identity.Url != null)
+                {
+                    parentWeb = parentWeb.GetWebByUrl(Identity.Url);
+                }
             }
+
+            var allWebs = GetSubWebsInternal(parentWeb.Webs, Recurse);
+            WriteObject(allWebs, true);
         }
 
-        private List<Web> GetSubWebsInternal(Web subweb)
+        private List<Web> GetSubWebsInternal(WebCollection subsites, bool recurse)
         {
             var subwebs = new List<Web>();
-            subweb.Webs.EnsureProperties(RetrievalExpressions);
-            subwebs.AddRange(subweb.Webs);
-            foreach (var sw in subweb.Webs)
+
+            // Retrieve the subsites in the provided webs collection
+            subsites.EnsureProperties(new Expression<Func<WebCollection, object>>[] { wc => wc.Include(w => w.Id) });
+
+            foreach (var subsite in subsites)
             {
-                subwebs.AddRange(GetSubWebsInternal(sw));
+                // Retrieve all the properties for this particular subsite
+                subsite.EnsureProperties(RetrievalExpressions);
+                subwebs.Add(subsite);
+
+                if (recurse)
+                {
+                    // As the Recurse flag has been set, recurse this method for it's child web collection
+                    subwebs.AddRange(GetSubWebsInternal(subsite.Webs, recurse));
+                }
             }
+
             return subwebs;
         }
     }

--- a/Commands/Web/GetSubwebs.cs
+++ b/Commands/Web/GetSubwebs.cs
@@ -30,29 +30,28 @@ namespace SharePointPnP.PowerShell.Commands
             {
                 WriteObject(SelectedWeb.Webs, true);
             }
-        //    else
-        //    {
-        //        var subwebs = new List<web>();
-        //        subwebs.AddRange(webs);
-        //        foreach (var subweb in webs)
-        //        {
-        //            subwebs.AddRange(GetSubWebsInternal(subweb));
-        //        }
-        //        WriteObject(subwebs, true);
-        //    }
+            else
+            {
+                var subwebs = new List<Web>();
+                subwebs.AddRange(SelectedWeb.Webs);
+                foreach (var subweb in SelectedWeb.Webs)
+                {
+                    subwebs.AddRange(GetSubWebsInternal(subweb));
+                }
+                WriteObject(subwebs, true);
+            }
         }
 
-        //private List<web> GetSubWebsInternal(web subweb)
-        //{
-        //    var subwebs = new List<web>();
-        //    var webs = subweb.Context.LoadQuery(subweb.Webs);
-        //    subweb.Context.ExecuteQueryRetry();
-        //    subwebs.AddRange(webs);
-        //    foreach (var sw in webs)
-        //    {
-        //        subwebs.AddRange(GetSubWebsInternal(sw));
-        //    }
-        //    return subwebs;
-        //}
+        private List<Web> GetSubWebsInternal(Web subweb)
+        {
+            var subwebs = new List<Web>();
+            subweb.Webs.EnsureProperties(RetrievalExpressions);
+            subwebs.AddRange(subweb.Webs);
+            foreach (var sw in subweb.Webs)
+            {
+                subwebs.AddRange(GetSubWebsInternal(sw));
+            }
+            return subwebs;
+        }
     }
 }

--- a/Documentation/GetPnPSubWebs.md
+++ b/Documentation/GetPnPSubWebs.md
@@ -4,16 +4,18 @@ Returns the subwebs of the current web
 ```powershell
 Get-PnPSubWebs [-Recurse [<SwitchParameter>]]
                [-Web <WebPipeBind>]
+               [-Includes <String[]>]
                [-Identity <WebPipeBind>]
 ```
 
 
 ## Returns
->[List<Microsoft.SharePoint.Client.Web>](https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.web.aspx)
+>[Microsoft.SharePoint.Client.WebCollection](https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.web.aspx)
 
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
 |Identity|WebPipeBind|False||
+|Includes|String[]|False|Specify properties to include when retrieving objects from the server.|
 |Recurse|SwitchParameter|False||
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Changed inheritance to PnPWebRetrievalsCmdlet so it also supports the -Include argument. Discussed in https://github.com/SharePoint/PnP-PowerShell/pull/973.