### PR TITLE
Support all characters for copy pnp file

### DIFF
--- a/Commands/Files/CopyFile.cs
+++ b/Commands/Files/CopyFile.cs
@@ -255,8 +255,47 @@ namespace SharePointPnP.PowerShell.Commands.Files
             var binaryStream = srcFile.OpenBinaryStream();
             _sourceContext.ExecuteQueryRetry();
             if (string.IsNullOrWhiteSpace(filename)) filename = srcFile.Name;
-            targetFolder.UploadFile(filename, binaryStream.Value, OverwriteIfAlreadyExists);
+            this.UploadFileWithInvalidCharacters(targetFolder, filename, binaryStream.Value, OverwriteIfAlreadyExists);
             _targetContext.ExecuteQueryRetry();
+        }
+
+
+        private File UploadFileWithInvalidCharacters(Folder folder, string fileName, System.IO.Stream stream, bool overwriteIfExists)
+        {
+            if (fileName == null)
+            {
+                throw new ArgumentNullException(nameof(fileName));
+            }
+
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentException("Filename is required");
+            }
+            /*
+            if (Regex.IsMatch(fileName, REGEX_INVALID_FILE_NAME_CHARS))
+            {
+                throw new ArgumentException(CoreResources.FileFolderExtensions_UploadFile_The_argument_must_be_a_single_file_name_and_cannot_contain_path_characters_, nameof(fileName));
+            }
+            */
+
+            // Create the file
+            var newFileInfo = new FileCreationInformation()
+            {
+                ContentStream = stream,
+                Url = fileName,
+                Overwrite = overwriteIfExists
+            };
+
+            var file = folder.Files.Add(newFileInfo);
+            folder.Context.Load(file);
+            folder.Context.ExecuteQueryRetry();
+
+            return file;
         }
     }
 }

--- a/Tests/FilesTest.cs
+++ b/Tests/FilesTest.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.SharePoint.Client;
+using System.Management.Automation.Runspaces;
+using System.Collections;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+
+namespace SharePointPnP.PowerShell.Tests
+{
+    [TestClass]
+    public class FilesTests
+    {
+        private const string targetLibraryRelativeUrl = "/sites/dev/Shared%20Documents";
+        private const string targetLibraryName = "Documents";
+        private const string targetLibraryDesc = "Documents library for Files testing";
+        private const string targetFileName = "Testfile.txt";
+        private const string targetFileContents = "Some random file contents";
+        private const string targetCopyFolderName = "CopyDestination";
+        private const string targetFileNameWithAmpersand = "Test & file.txt";
+        private const string targetSite2LibraryRelativeUrl = "/sites/dev2/Shared%20Documents";
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            //With thanks to Paolo Pialorsi https://piasys.com/blog/uploading-a-file-into-a-library-via-csom-even-if-the-library-does-not-exist/
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                ExceptionHandlingScope scope = new ExceptionHandlingScope(ctx);
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        Folder folder = ctx.Web.GetFolderByServerRelativeUrl(targetLibraryRelativeUrl);
+                    }
+                    using (scope.StartCatch())
+                    {
+                        // Create the library, in case it doesn’t exist
+                        ListCreationInformation lci = new ListCreationInformation();
+                        lci.Title = targetLibraryName;
+                        lci.Description = targetLibraryDesc;
+                        lci.TemplateType = (Int32)ListTemplateType.DocumentLibrary;
+                        lci.QuickLaunchOption = QuickLaunchOptions.On;
+                        List library = ctx.Web.Lists.Add(lci);
+                    }
+                    using (scope.StartFinally())
+                    {
+                        Folder folder = ctx.Web.GetFolderByServerRelativeUrl(targetLibraryRelativeUrl);
+                        FileCreationInformation fci = new FileCreationInformation();
+                        fci.Content = Encoding.ASCII.GetBytes(targetFileContents);
+                        fci.Url = targetFileName;
+                        fci.Overwrite = true;
+                        File fileToUpload = folder.Files.Add(fci);
+                        ctx.Load(fileToUpload);
+
+                        fci.Url = targetFileNameWithAmpersand;
+                        fci.Overwrite = true;
+                        fileToUpload = folder.Files.Add(fci);
+                        ctx.Load(fileToUpload);
+
+                        folder.Folders.Add(targetCopyFolderName);
+                    }
+                }
+                ctx.ExecuteQuery();
+            }
+        }
+        
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                ExceptionHandlingScope scope = new ExceptionHandlingScope(ctx);
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        File initialFile = ctx.Web.GetFileByServerRelativeUrl(targetLibraryRelativeUrl + "/" + targetFileName);
+                        if (initialFile != null)
+                        {
+                            initialFile.DeleteObject();
+                        }
+                        Folder copyFolder = ctx.Web.GetFolderByServerRelativeUrl(targetLibraryRelativeUrl + "/" + targetCopyFolderName);
+                        if (copyFolder != null)
+                        {
+                            copyFolder.DeleteObject();
+                        }
+                    }
+                    using (scope.StartCatch())
+                    {
+                        // Ignore as file not created or already deleted
+                    }
+                }
+                ctx.ExecuteQuery();
+            }
+
+            using (var ctx = TestCommon.CreateClientContextDev2())
+            {
+                ExceptionHandlingScope scope = new ExceptionHandlingScope(ctx);
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        File initialFile = ctx.Web.GetFileByServerRelativeUrl(targetSite2LibraryRelativeUrl + "/" + targetFileName);
+                        if (initialFile != null)
+                        {
+                            initialFile.DeleteObject();
+                        }
+                        File ampersandFile = ctx.Web.GetFileByServerRelativeUrl(targetSite2LibraryRelativeUrl + "/" + targetFileNameWithAmpersand);
+                        if (ampersandFile != null)
+                        {
+                            ampersandFile.DeleteObject();
+                        }
+                    }
+                    using (scope.StartCatch())
+                    {
+                        // Ignore as file not created or already deleted
+                    }
+                }
+                ctx.ExecuteQuery();
+            }
+        }
+
+        [TestMethod]
+        public void GetFile_AsListItem_Test()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                var values = new Hashtable();
+                values.Add("Title", "Test");
+                //Get-PnPFile -Url /sites/project/_catalogs/themes/15/company.spcolor -AsFile",
+                var results = scope.ExecuteCommand("Get-PnPFile",
+                    new CommandParameter("Url", System.IO.Path.Combine(targetLibraryRelativeUrl,targetFileName)),
+                    new CommandParameter("AsListItem"));
+
+                Assert.IsTrue(results.Any());
+
+                Assert.IsTrue(results[0].BaseObject.GetType() == typeof(Microsoft.SharePoint.Client.ListItem));
+            }
+        }
+
+        [TestMethod]
+        public void GetFile_AsFile_Test()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                var results = scope.ExecuteCommand("Get-PnPFile",
+                    new CommandParameter("Url", System.IO.Path.Combine(targetLibraryRelativeUrl, targetFileName)),
+                    new CommandParameter("AsFile"));
+
+                Assert.IsTrue(results.Any());
+
+                Assert.IsTrue(results[0].BaseObject.GetType() == typeof(Microsoft.SharePoint.Client.File));
+            }
+        }
+
+        [TestMethod]
+        public void CopyFileTest()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                string sourceUrl = targetLibraryRelativeUrl + "/" + targetFileName;
+                string destinationUrl = targetLibraryRelativeUrl + "/" + targetCopyFolderName + "/" + targetFileName;
+                var results = scope.ExecuteCommand("Copy-PnPFile",
+                    new CommandParameter("SourceUrl", sourceUrl),
+                    new CommandParameter("TargetUrl", destinationUrl),
+                    new CommandParameter("Force"));
+
+                using (var ctx = TestCommon.CreateClientContext())
+                {
+                    File initialFile = ctx.Web.GetFileByServerRelativeUrl(destinationUrl);
+                    if (initialFile == null)
+                    {
+                        Assert.Fail("Copied file cannot be found");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CopyFile_WithAmpersand_Test()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                string sourceUrl = targetLibraryRelativeUrl + "/" + targetFileNameWithAmpersand;
+                string destinationUrl = targetLibraryRelativeUrl + "/" + targetCopyFolderName + "/" + targetFileNameWithAmpersand;
+                var results = scope.ExecuteCommand("Copy-PnPFile",
+                    new CommandParameter("SourceUrl", sourceUrl),
+                    new CommandParameter("TargetUrl", destinationUrl),
+                    new CommandParameter("Force"));
+
+                using (var ctx = TestCommon.CreateClientContext())
+                {
+                    File initialFile = ctx.Web.GetFileByServerRelativeUrl(destinationUrl);
+                    if (initialFile == null)
+                    {
+                        Assert.Fail("Copied file cannot be found");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CopyFile_BetweenSiteCollections_Test()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                string sourceUrl = targetLibraryRelativeUrl + "/" + targetFileName;
+                string destinationFolderUrl = targetSite2LibraryRelativeUrl;
+                string destinationFileUrl = targetSite2LibraryRelativeUrl + "/" + targetFileName;
+                var results = scope.ExecuteCommand("Copy-PnPFile",
+                    new CommandParameter("SourceUrl", sourceUrl),
+                    new CommandParameter("TargetUrl", destinationFolderUrl),
+                    new CommandParameter("Force"));
+
+                using (var ctx = TestCommon.CreateClientContextDev2())
+                {
+                    File initialFile = ctx.Web.GetFileByServerRelativeUrl(destinationFileUrl);
+                    ctx.Load(initialFile);
+                    ctx.ExecuteQuery();
+                    if (!initialFile.Exists)
+                    {
+                        Assert.Fail("Copied file cannot be found");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CopyFile_BetweenSiteCollectionsWithAmpersand_Test()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                string sourceUrl = targetLibraryRelativeUrl + "/" + targetFileNameWithAmpersand;
+                string destinationFolderUrl = targetSite2LibraryRelativeUrl;
+                string destinationFileUrl = targetSite2LibraryRelativeUrl + "/" + targetFileNameWithAmpersand;
+                var results = scope.ExecuteCommand("Copy-PnPFile",
+                    new CommandParameter("SourceUrl", sourceUrl),
+                    new CommandParameter("TargetUrl", destinationFolderUrl),
+                    new CommandParameter("Force"));
+
+                using (var ctx = TestCommon.CreateClientContextDev2())
+                {
+                    File initialFile = ctx.Web.GetFileByServerRelativeUrl(destinationFileUrl);
+                    ctx.Load(initialFile);
+                    ctx.ExecuteQuery();
+                    if (!initialFile.Exists)
+                    {
+                        Assert.Fail("Copied file cannot be found");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/PSTestScope.cs
+++ b/Tests/PSTestScope.cs
@@ -57,7 +57,7 @@ namespace SharePointPnP.PowerShell.Tests
                 }
                 else
                 {
-                    if (!string.IsNullOrEmpty("AppId") && !string.IsNullOrEmpty("AppSecret"))
+                    if (!string.IsNullOrEmpty(AppId) && !string.IsNullOrEmpty(AppSecret))
                     {
                         // Use oAuth Token to authenticate
                         if (!string.IsNullOrEmpty(Realm))

--- a/Tests/SharePointPnP.PowerShell.Tests.csproj
+++ b/Tests/SharePointPnP.PowerShell.Tests.csproj
@@ -275,6 +275,7 @@
     <Compile Include="EventReceiverTests.cs" />
     <Compile Include="FeatureTests.cs" />
     <Compile Include="FieldsTests.cs" />
+    <Compile Include="FilesTest.cs" />
     <Compile Include="InvokeWebActionTest.cs" />
     <Compile Include="ListDataRowProvisioningTemplate.cs" />
     <Compile Include="ProvisioningTemplateTests.cs" />

--- a/Tests/TestCommon.cs
+++ b/Tests/TestCommon.cs
@@ -17,6 +17,7 @@ namespace SharePointPnP.PowerShell.Tests
             // Read configuration data
             TenantUrl = ConfigurationManager.AppSettings["SPOTenantUrl"];
             DevSiteUrl = ConfigurationManager.AppSettings["SPODevSiteUrl"];
+            Dev2SiteUrl = ConfigurationManager.AppSettings["SPODev2SiteUrl"];
 
             if (string.IsNullOrEmpty(TenantUrl) || string.IsNullOrEmpty(DevSiteUrl))
             {
@@ -77,6 +78,7 @@ namespace SharePointPnP.PowerShell.Tests
         #region Properties
         public static string TenantUrl { get; set; }
         public static string DevSiteUrl { get; set; }
+        public static string Dev2SiteUrl { get; set; }
         static string UserName { get; set; }
         static SecureString Password { get; set; }
         static ICredentials Credentials { get; set; }
@@ -105,6 +107,11 @@ namespace SharePointPnP.PowerShell.Tests
         public static ClientContext CreateClientContext()
         {
             return CreateContext(DevSiteUrl, Credentials);
+        }
+
+        public static ClientContext CreateClientContextDev2()
+        {
+            return CreateContext(Dev2SiteUrl, Credentials);
         }
 
         public static ClientContext CreateTenantClientContext()
@@ -138,18 +145,18 @@ namespace SharePointPnP.PowerShell.Tests
             {
                 OfficeDevPnP.Core.AuthenticationManager am = new OfficeDevPnP.Core.AuthenticationManager();
 
-                if (new Uri(DevSiteUrl).DnsSafeHost.Contains("spoppe.com"))
+                if (new Uri(contextUrl).DnsSafeHost.Contains("spoppe.com"))
                 {
-                    context = am.GetAppOnlyAuthenticatedContext(DevSiteUrl, SPOnlineConnectionHelper.GetRealmFromTargetUrl(new Uri(DevSiteUrl)), AppId, AppSecret, acsHostUrl: "windows-ppe.net", globalEndPointPrefix: "login");
+                    context = am.GetAppOnlyAuthenticatedContext(contextUrl, SPOnlineConnectionHelper.GetRealmFromTargetUrl(new Uri(contextUrl)), AppId, AppSecret, acsHostUrl: "windows-ppe.net", globalEndPointPrefix: "login");
                 }
                 else
                 {
-                    context = am.GetAppOnlyAuthenticatedContext(DevSiteUrl, AppId, AppSecret);
+                    context = am.GetAppOnlyAuthenticatedContext(contextUrl, AppId, AppSecret);
                 }
             }
             else
             {
-                context = new ClientContext(DevSiteUrl);
+                context = new ClientContext(contextUrl);
                 context.Credentials = Credentials;
             }
 


### PR DESCRIPTION
## Type ##
- [x ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1051 

## What is in this Pull Request ? ##
To help diagnose issue #1051, I have added some tests for GetFile and CopyFile. This also required adding a second ClientContext for another site collection to test copy between two different site collections - however, I think that there must be a better way to handle this.

This also includes a change to CopyFile so that it allows files to be uploaded with ampersands and other characters which are now allowed in SharePoint Online. 

