### PR TITLE
Fixes typos in documentation + changed the CommentsEnabled argument type

### DIFF
--- a/Commands/Base/PipeBinds/ClientSidePagePipeBind.cs
+++ b/Commands/Base/PipeBinds/ClientSidePagePipeBind.cs
@@ -17,7 +17,15 @@ namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
         public ClientSidePagePipeBind(ClientSidePage page)
         {
             _page = page;
-            _name = page.PageTitle;
+            if (page.PageListItem != null)
+            {
+                File file = page.PageListItem.EnsureProperty(li => li.File);
+                _name = file.EnsureProperty(f => f.Name);
+            }
+            else
+            {
+                _name = page.PageTitle;
+            }
         }
 
         public ClientSidePagePipeBind(string name)

--- a/Commands/ClientSidePages/AddClientSidePage.cs
+++ b/Commands/ClientSidePages/AddClientSidePage.cs
@@ -11,9 +11,13 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
     [CmdletHelp("Adds a Client-Side Page",
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPClientSidePage -PageName ""OurNewPage""",
-        Remarks = "Creates a new Client-Side page called 'OurNewPage'",
+        Code = @"PS:> Add-PnPClientSidePage -Name ""NewPage""",
+        Remarks = "Creates a new Client-Side page named 'NewPage'",
         SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPClientSidePage ""NewPage""",
+        Remarks = "Creates a new Client-Side page named 'NewPage'",
+        SortOrder = 2)]
     public class AddClientSidePage : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "Specifies the name of the page.")]
@@ -26,7 +30,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         public ClientSidePagePromoteType PromoteAs = ClientSidePagePromoteType.None;
 
         [Parameter(Mandatory = false, HelpMessage = "Enables or Disables the comments on the page")]
-        public bool? CommentsEnabled = null;
+        public SwitchParameter CommentsEnabled = false;
 
         [Parameter(Mandatory = false, HelpMessage = "Publishes the page once it is saved. Applicable to libraries set to create major and minor versions.")]
         public SwitchParameter Publish;
@@ -75,9 +79,10 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
                     break;
             }
 
-            if (CommentsEnabled.HasValue)
+
+            if (MyInvocation.BoundParameters.ContainsKey("CommentsEnabled"))
             {
-                if (CommentsEnabled.Value)
+                if (CommentsEnabled)
                 {
                     clientSidePage.EnableComments();
                 }

--- a/Commands/ClientSidePages/AddClientSidePage.cs
+++ b/Commands/ClientSidePages/AddClientSidePage.cs
@@ -20,7 +20,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         SortOrder = 2)]
     public class AddClientSidePage : PnPWebCmdlet
     {
-        [Parameter(Mandatory = true, HelpMessage = "Specifies the name of the page.")]
+        [Parameter(Mandatory = true, Position = 0, HelpMessage = "Specifies the name of the page.")]
         public string Name = null;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifies the layout type of the page.")]

--- a/Commands/ClientSidePages/AddClientSidePageSection.cs
+++ b/Commands/ClientSidePages/AddClientSidePageSection.cs
@@ -22,7 +22,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         Code = @"PS:> $page = Add-PnPClientSidePage -Name ""MyPage""
 PS> Add-PnPClientSidePageSection -Page $page -SectionTemplate OneColumn",
         Remarks = "Adds a new one column section to the Client-Side page 'MyPage'",
-        SortOrder = 2)]
+        SortOrder = 3)]
     public class AddClientSidePageSection : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The name of the page")]

--- a/Commands/ClientSidePages/AddClientSideText.cs
+++ b/Commands/ClientSidePages/AddClientSideText.cs
@@ -11,8 +11,8 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
     [CmdletHelp("Adds a Client-Side Page",
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPClientSideText -Page ""OurNewPage"" -Text ""Hello World!""",
-        Remarks = "Adds the text 'Hello World!' to the Client-Side Page 'OurNewPage'",
+        Code = @"PS:> Add-PnPClientSideText -Page ""MyPage"" -Text ""Hello World!""",
+        Remarks = "Adds the text 'Hello World!' to the Client-Side Page 'MyPage'",
         SortOrder = 1)]
     public class AddClientSideText : PnPWebCmdlet
     {

--- a/Commands/ClientSidePages/AddClientSideWebPart.cs
+++ b/Commands/ClientSidePages/AddClientSideWebPart.cs
@@ -11,17 +11,17 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
     [CmdletHelp("Adds a Client-Side Component to a page",
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPClientSideWebPart -Page ""OurNewPage"" -DefaultWebPartType BingMap",
-        Remarks = "Adds a built-in Client-Side component 'BingMap' to the page called 'OurNewPage'",
+        Code = @"PS:> Add-PnPClientSideWebPart -Page ""MyPage"" -DefaultWebPartType BingMap",
+        Remarks = "Adds a built-in Client-Side component 'BingMap' to the page called 'MyPage'",
         SortOrder = 2)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPClientSideWebPart -Page ""OurNewPage"" -Component ""HelloWorld""",
-        Remarks = "Adds a Client-Side component 'HelloWorld' to the page called 'OurNewPage'",
-        SortOrder = 2)]
-    [CmdletExample(
-        Code = @"PS:> Add-PnPClientSideWebPart  -Page ""OurNewPage"" -Component ""HelloWorld"" -Section 1 -Column 2",
-        Remarks = "Adds a Client-Side component 'HelloWorld' to the page called 'OurNewPage' in section 1 and column 2",
+        Code = @"PS:> Add-PnPClientSideWebPart -Page ""MyPage"" -Component ""HelloWorld""",
+        Remarks = "Adds a Client-Side component 'HelloWorld' to the page called 'MyPage'",
         SortOrder = 3)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPClientSideWebPart  -Page ""MyPage"" -Component ""HelloWorld"" -Section 1 -Column 2",
+        Remarks = "Adds a Client-Side component 'HelloWorld' to the page called 'MyPage' in section 1 and column 2",
+        SortOrder = 4)]
     public class AddClientSideWebPart : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The name of the page.", ParameterSetName = "DefaultBuiltIn")]

--- a/Commands/ClientSidePages/GetAvailableClientSideComponents.cs
+++ b/Commands/ClientSidePages/GetAvailableClientSideComponents.cs
@@ -10,7 +10,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
     [CmdletHelp("Gets the available client side components on a particular page",
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPAvailableClientSideComponents -Identity ""MyPage.aspx""",
+        Code = @"PS:> Get-PnPAvailableClientSideComponents -Page ""MyPage.aspx""",
         Remarks = "Gets the list of available client side components on the page 'MyPage.aspx'",
         SortOrder = 1)]
     [CmdletExample(
@@ -18,7 +18,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         Remarks = "Gets the list of available client side components on the page contained in the $page variable",
         SortOrder = 2)]
     [CmdletExample(
-        Code = @"PS:> Get-PnPAvailableClientSideComponents -Identity ""MyPage.aspx"" -ComponentName ""HelloWorld""",
+        Code = @"PS:> Get-PnPAvailableClientSideComponents -Page ""MyPage.aspx"" -ComponentName ""HelloWorld""",
         Remarks = "Gets the client side component 'HelloWorld' if available on the page 'MyPage.aspx'",
         SortOrder = 3)]
     public class GetAvailableClientSideComponents : PnPWebCmdlet

--- a/Commands/ClientSidePages/GetClientSidePage.cs
+++ b/Commands/ClientSidePages/GetClientSidePage.cs
@@ -11,11 +11,11 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
      [CmdletExample(
         Code = @"PS:> Get-PnPClientSidePage -Identity ""MyPage.aspx""",
-        Remarks = "Gets the Modern Page (Client-Side) called 'MyPage.aspx' in the current SharePoint site",
+        Remarks = "Gets the Modern Page (Client-Side) named 'MyPage.aspx' in the current SharePoint site",
         SortOrder = 2)]
     [CmdletExample(
         Code = @"PS:> Get-PnPClientSidePage ""MyPage""",
-        Remarks = "Gets the Modern Page (Client-Side) called 'MyPage.aspx' in the current SharePoint site",
+        Remarks = "Gets the Modern Page (Client-Side) named 'MyPage.aspx' in the current SharePoint site",
         SortOrder = 2)]
     public class GetClientSidePage : PnPWebCmdlet
     {

--- a/Commands/ClientSidePages/RemoveClientSidePage.cs
+++ b/Commands/ClientSidePages/RemoveClientSidePage.cs
@@ -12,7 +12,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
         Code = @"PS:> Remove-PnPClientSidePage -Identity ""MyPage""",
-        Remarks = "Removes the Client-Side page called 'MyPage.aspx'",
+        Remarks = "Removes the Client-Side page named 'MyPage.aspx'",
         SortOrder = 1)]
     [CmdletExample(
         Code = @"PS:> Remove-PnPClientSidePage $page",

--- a/Commands/ClientSidePages/SetClientSidePage.cs
+++ b/Commands/ClientSidePages/SetClientSidePage.cs
@@ -12,8 +12,16 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
         Code = @"PS:> Set-PnPClientSidePage -Identity ""MyPage"" -LayoutType Home",
-        Remarks = "Updates the properties of the Client-Side page called 'MyPage'",
+        Remarks = "Updates the properties of the Client-Side page name 'MyPage'",
         SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Set-PnPClientSidePage -Identity ""MyPage"" -CommentsEnabled",
+        Remarks = "Enables the comments on the Client-Side page named 'MyPage'",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Set-PnPClientSidePage -Identity ""MyPage"" -CommentsEnabled $false",
+        Remarks = "Disables the comments on the Client-Side page named 'MyPage'",
+        SortOrder = 3)]
     public class SetClientSidePage : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The name/identity of the page")]
@@ -29,7 +37,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         public ClientSidePagePromoteType PromoteAs = ClientSidePagePromoteType.None;
 
         [Parameter(Mandatory = false, HelpMessage = "Enables or Disables the comments on the page")]
-        public bool? CommentsEnabled = null;
+        public SwitchParameter CommentsEnabled = false;
 
         [Parameter(Mandatory = false, HelpMessage = "Publishes the page once it is saved.")]
         public SwitchParameter Publish;
@@ -49,7 +57,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
             // We need to have the page name, if not found, raise an error
             string name = ClientSidePageUtilities.EnsureCorrectPageName(Name ?? Identity?.Name);
             if (name == null)
-                throw new Exception("Insufficient arguments to add a client side page");
+                throw new Exception("Insufficient arguments to update a client side page");
 
             clientSidePage.LayoutType = LayoutType;
             clientSidePage.Save(name);
@@ -68,9 +76,9 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
                     break;
             }
 
-            if (CommentsEnabled.HasValue)
+            if (MyInvocation.BoundParameters.ContainsKey("CommentsEnabled"))
             {
-                if (CommentsEnabled.Value)
+                if (CommentsEnabled)
                 {
                     clientSidePage.EnableComments();
                 }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes typos and documentation mismatch in PR #1054 

## What is in this Pull Request ? ##
- Fixes typos, docs mismatch and improve consistency across Doc examples
- Converted CommentsEnabled argument to be a switch parameter instead of a nullable boolean
- The AddPnPClientSidePage cmdlet has now the Name argument as first position (It allows to use "Add-PnPClientSidePage "mypage" )
- Ensures the ClientSidePagePipeBind has always a value for the _name field. When the piped object is a ClientSidePage object, the name of the underlying file is fetched.
