### PR TITLE
Introduced -Confirm with Remove-PnPJavaScriptLink and Remove-PnPCustomAction

### DIFF
--- a/Commands/Base/PipeBinds/CustomActionPipeBind.cs
+++ b/Commands/Base/PipeBinds/CustomActionPipeBind.cs
@@ -1,4 +1,3 @@
-﻿using Microsoft.SharePoint.Client;
 using System;
 
 namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds

--- a/Commands/Base/PipeBinds/CustomActionPipeBind.cs
+++ b/Commands/Base/PipeBinds/CustomActionPipeBind.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.SharePoint.Client;
+using System;
+
+namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
+{
+    /// <summary>
+    /// Allows passing UserCustomAction objects in pipelines
+    /// </summary>
+    public sealed class UserCustomActionPipeBind
+    {
+        /// <summary>
+        /// Id of the UserCustomAction
+        /// </summary>
+        public Guid? Id { get; private set; }
+
+        /// <summary>
+        /// Name of the UserCustomAction
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// The UserCustomAction that is piped in
+        /// </summary>
+        public UserCustomAction UserCustomAction { get; private set; }
+
+        /// <summary>
+        /// Accepts an id of a UserCustomAction
+        /// </summary>
+        /// <param name="guid">Id of the UserCustomAction</param>
+        public UserCustomActionPipeBind(Guid guid)
+        {
+            Id = guid;
+        }
+
+        /// <summary>
+        /// Accepts a UserCustomAction to be passed in
+        /// </summary>
+        /// <param name="userCustomAction">UserCustomAction itself</param>
+        public UserCustomActionPipeBind(UserCustomAction userCustomAction)
+        {
+            UserCustomAction = userCustomAction;
+        }
+
+        /// <summary>
+        /// Accepts a name or id to be passed in
+        /// </summary>
+        /// <param name="id">Name or id of the UserCustomAction</param>
+        public UserCustomActionPipeBind(string id)
+        {
+            // Added Guid checking first for backwards compatibility
+            if (Guid.TryParse(id, out Guid result))
+            {
+                Id = result;
+            }
+            else
+            {
+                Name = id;
+            }
+        }
+    }
+}

--- a/Commands/Branding/RemoveCustomAction.cs
+++ b/Commands/Branding/RemoveCustomAction.cs
@@ -28,7 +28,7 @@ namespace SharePointPnP.PowerShell.Commands.Branding
         {
             if (Identity != null)
             {
-                if (Force || ShouldContinue(Resources.RemoveCustomAction, Resources.Confirm))
+                if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(Resources.RemoveCustomAction, Resources.Confirm))
                 {
                     if (Scope == CustomActionScope.All || Scope == CustomActionScope.Web)
                     {

--- a/Commands/Branding/RemoveJavaScriptLink.cs
+++ b/Commands/Branding/RemoveJavaScriptLink.cs
@@ -66,7 +66,7 @@ namespace SharePointPnP.PowerShell.Commands.Branding
                 actions = actions.Where(action => action.Name == Name).ToList();
             }
 
-            foreach (var action in actions.Where(action => Force || ShouldContinue(string.Format(Resources.RemoveJavaScript0, action.Name), Resources.Confirm)))
+            foreach (var action in actions.Where(action => Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Resources.RemoveJavaScript0, action.Name), Resources.Confirm)))
             {
                 switch (action.Scope)
                 {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/955. Cleaned up submit.

## What is in this Pull Request ? ##
Introduced the ability to use -Confirm with Remove-PnPJavaScriptLink and Remove-PnPCustomAction to be in line with standard PowerShell. The -Force parameter to achieve the same still works for backwards compatibility as well.