### PR TITLE
Allow remove all for Remove-PnPCustomAction and Remove-PnPJavaScriptLink

### DIFF
--- a/Commands/Branding/RemoveCustomAction.cs
+++ b/Commands/Branding/RemoveCustomAction.cs
@@ -4,18 +4,26 @@ using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 using SharePointPnP.PowerShell.Commands.Enums;
 using Resources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SharePointPnP.PowerShell.Commands.Branding
 {
     [Cmdlet(VerbsCommon.Remove, "PnPCustomAction", ConfirmImpact = ConfirmImpact.High, SupportsShouldProcess = true)]
     [CmdletHelp("Removes a custom action", 
         Category = CmdletHelpCategory.Branding)]
-    [CmdletExample(Code = @"PS:> Remove-PnPCustomAction -Identity aa66f67e-46c0-4474-8a82-42bf467d07f2", Remarks = @"Removes the custom action with the id 'aa66f67e-46c0-4474-8a82-42bf467d07f2'.", SortOrder = 1)]
-    [CmdletExample(Code = @"PS:> Remove-PnPCustomAction -Identity aa66f67e-46c0-4474-8a82-42bf467d07f2 -scope web", Remarks = @"Removes the custom action with the id 'aa66f67e-46c0-4474-8a82-42bf467d07f2' from the current web.", SortOrder = 2)]
-    [CmdletExample(Code = @"PS:> Remove-PnPCustomAction -Identity aa66f67e-46c0-4474-8a82-42bf467d07f2 -force", Remarks = @"Removes the custom action with the id 'aa66f67e-46c0-4474-8a82-42bf467d07f2' without asking for confirmation.", SortOrder = 3)]
+    [CmdletExample(Code = @"PS:> Remove-PnPCustomAction -Identity aa66f67e-46c0-4474-8a82-42bf467d07f2", 
+                   Remarks = @"Removes the custom action with the id 'aa66f67e-46c0-4474-8a82-42bf467d07f2'.", 
+                   SortOrder = 1)]
+    [CmdletExample(Code = @"PS:> Remove-PnPCustomAction -Identity aa66f67e-46c0-4474-8a82-42bf467d07f2 -scope web", 
+                   Remarks = @"Removes the custom action with the id 'aa66f67e-46c0-4474-8a82-42bf467d07f2' from the current web.", 
+                   SortOrder = 2)]
+    [CmdletExample(Code = @"PS:> Remove-PnPCustomAction -Identity aa66f67e-46c0-4474-8a82-42bf467d07f2 -force", 
+                   Remarks = @"Removes the custom action with the id 'aa66f67e-46c0-4474-8a82-42bf467d07f2' without asking for confirmation.", 
+                   SortOrder = 3)]
     public class RemoveCustomAction : PnPWebCmdlet
     {
-        [Parameter(Mandatory = true, Position=0, ValueFromPipeline=true, HelpMessage = "The identifier of the CustomAction that needs to be removed")]
+        [Parameter(Mandatory = false, Position=0, ValueFromPipeline=true, HelpMessage = "The identifier of the CustomAction that needs to be removed")]
         public GuidPipeBind Identity;
 
         [Parameter(Mandatory = false, HelpMessage = "Define if the CustomAction is to be found at the web or site collection scope. Specify All to allow deletion from either web or site collection.")]
@@ -26,18 +34,44 @@ namespace SharePointPnP.PowerShell.Commands.Branding
 
         protected override void ExecuteCmdlet()
         {
+            List<UserCustomAction> actions = new List<UserCustomAction>();
+
+            if (Scope == CustomActionScope.All || Scope == CustomActionScope.Web)
+            {
+                actions.AddRange(SelectedWeb.GetCustomActions());
+            }
+            if (Scope == CustomActionScope.All || Scope == CustomActionScope.Site)
+            {
+                actions.AddRange(ClientContext.Site.GetCustomActions());
+            }
+
             if (Identity != null)
             {
-                if (Force || ShouldContinue(Resources.RemoveCustomAction, Resources.Confirm))
+                actions = actions.Where(action => action.Id == Identity.Id).ToList();
+
+                if (!actions.Any())
                 {
-                    if (Scope == CustomActionScope.All || Scope == CustomActionScope.Web)
-                    {
+                    throw new PSArgumentException($"No CustomAction found with the Id '{Identity.Id}' within the scope '{Scope}'", "Identity");
+                }
+            }
+
+            if (!actions.Any())
+            {
+                WriteVerbose($"No CustomAction found within the scope '{Scope}'");
+                return;
+            }
+
+            foreach (var action in actions.Where(action => Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Resources.RemoveCustomAction, action.Name, action.Id, action.Scope), Resources.Confirm)))
+            {
+                switch (action.Scope)
+                {
+                    case UserCustomActionScope.Web:
                         SelectedWeb.DeleteCustomAction(Identity.Id);
-                    }
-                    if (Scope == CustomActionScope.All || Scope == CustomActionScope.Site)
-                    {
+                        break;
+
+                    case UserCustomActionScope.Site:
                         ClientContext.Site.DeleteCustomAction(Identity.Id);
-                    }
+                        break;
                 }
             }
         }

--- a/Commands/Branding/RemoveJavaScriptLink.cs
+++ b/Commands/Branding/RemoveJavaScriptLink.cs
@@ -59,14 +59,23 @@ namespace SharePointPnP.PowerShell.Commands.Branding
                 actions.AddRange(ClientContext.Site.GetCustomActions().Where(c => c.Location == "ScriptLink"));
             }
 
-            if (!actions.Any()) return;
-
-            if(!string.IsNullOrEmpty(Name))
+            if (!string.IsNullOrEmpty(Name))
             {
                 actions = actions.Where(action => action.Name == Name).ToList();
+
+                if (!actions.Any())
+                {
+                    throw new PSArgumentException($"No JavaScriptLink found with the name '{Name}' within the scope '{Scope}'", "Name");
+                }
             }
 
-            foreach (var action in actions.Where(action => Force || ShouldContinue(string.Format(Resources.RemoveJavaScript0, action.Name), Resources.Confirm)))
+            if (!actions.Any())
+            {
+                WriteVerbose($"No JavaScriptLink registrations found within the scope '{Scope}'");
+                return;
+            }
+
+            foreach (var action in actions.Where(action => Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Resources.RemoveJavaScript0, action.Name, action.Id, action.Scope), Resources.Confirm)))
             {
                 switch (action.Scope)
                 {

--- a/Commands/Properties/Resources.Designer.cs
+++ b/Commands/Properties/Resources.Designer.cs
@@ -360,7 +360,7 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove custom action?.
+        ///   Looks up a localized string similar to Remove CustomAction named &apos;{0}&apos; with id &apos;{1}&apos; on scope &apos;{2}&apos;?.
         /// </summary>
         internal static string RemoveCustomAction {
             get {
@@ -396,7 +396,7 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove JavaScript (&apos;{0}&apos;)?.
+        ///   Looks up a localized string similar to Remove JavaScriptLink named &apos;{0}&apos; with id &apos;{1}&apos; on scope &apos;{2}&apos;?.
         /// </summary>
         internal static string RemoveJavaScript0 {
             get {

--- a/Commands/Properties/Resources.resx
+++ b/Commands/Properties/Resources.resx
@@ -166,13 +166,13 @@
     <value>Remove content type?</value>
   </data>
   <data name="RemoveCustomAction" xml:space="preserve">
-    <value>Remove custom action?</value>
+    <value>Remove CustomAction named '{0}' with id '{1}' on scope '{2}'?</value>
   </data>
   <data name="RemoveEventReceiver" xml:space="preserve">
     <value>Remove event receiver?</value>
   </data>
   <data name="RemoveJavaScript0" xml:space="preserve">
-    <value>Remove JavaScript ('{0}')?</value>
+    <value>Remove JavaScriptLink named '{0}' with id '{1}' on scope '{2}'?</value>
   </data>
   <data name="RemoveKeyAndValueFromPropertyBag" xml:space="preserve">
     <value>Remove key and value from property bag?</value>

--- a/Documentation/RemovePnPCustomAction.md
+++ b/Documentation/RemovePnPCustomAction.md
@@ -2,18 +2,18 @@
 Removes a custom action
 ## Syntax
 ```powershell
-Remove-PnPCustomAction -Identity <GuidPipeBind>
-                       [-Scope <CustomActionScope>]
+Remove-PnPCustomAction [-Scope <CustomActionScope>]
                        [-Force [<SwitchParameter>]]
                        [-Web <WebPipeBind>]
+                       [-Identity <GuidPipeBind>]
 ```
 
 
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
-|Identity|GuidPipeBind|True|The identifier of the CustomAction that needs to be removed|
 |Force|SwitchParameter|False|Use the -Force flag to bypass the confirmation question|
+|Identity|GuidPipeBind|False|The identifier of the CustomAction that needs to be removed|
 |Scope|CustomActionScope|False|Define if the CustomAction is to be found at the web or site collection scope. Specify All to allow deletion from either web or site collection.|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ## Examples


### PR DESCRIPTION
…y, added verbose logging when requests yields no results, added the name, id and scope in the remove confirmation dialog

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/958

## What is in this Pull Request ? ##
Added option to remove all customactions by not specifying an identity, added verbose logging when requests yields no results, added the name, id and scope in the remove confirmation dialog.

Couldn't remove the .md from the commit. I haven't changed it, it's auto created.