### PR TITLE
Add description to Get-PnPTenantRecycleBinItem to clarify -admin requirement

### DIFF
--- a/Commands/RecycleBin/GetTenantRecycleBinItem.cs
+++ b/Commands/RecycleBin/GetTenantRecycleBinItem.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-#if !ONPREMISES
+﻿#if !ONPREMISES
 using System.Management.Automation;
 using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
@@ -10,6 +9,7 @@ namespace SharePointPnP.PowerShell.Commands.RecycleBin
 {
     [Cmdlet(VerbsCommon.Get, "PnPTenantRecycleBinItem", DefaultParameterSetName = "All")]
     [CmdletHelp("Returns the items in the tenant scoped recycle bin",
+        DetailedDescription = "This command will return all the items in the tenant recycle bin for the Office 365 tenant you're connected to. Be sure to connect to the SharePoint Online Admin endpoint (https://tenant-admin.sharepoint.com) in order for this command to work.",
         Category = CmdletHelpCategory.RecycleBin,
         SupportedPlatform = CmdletSupportedPlatform.Online,
         OutputType = typeof(DeletedSiteProperties),
@@ -29,7 +29,6 @@ namespace SharePointPnP.PowerShell.Commands.RecycleBin
             {
                 WriteObject(deletedSites, true);
             }
-
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [X] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/1047 to the proper dev branch

## What is in this Pull Request ? ##
Added description on this command to make clear that you need to connect to the -admin endpoint of SPO in order for the command to work. Otherwise you'll get a 403.

Retested this: when using a clientid/clientsecret and connecting to a normal sitecollection, it can't auto switch to the -admin context for this command and will throw:

> Get-PnPTenantRecycleBinItem : The remote server returned an error: (401) Unauthorized.
