### PR TITLE
Updated example on Get-PnPListItem

### DIFF
--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -20,27 +20,27 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         SortOrder = 1)]
     [CmdletExample(
         Code = "PS:> Get-PnPListItem -List Tasks -Id 1",
-        Remarks = "Retrieves the list item with ID 1 from from the Tasks list. This parameter is ignored if the Query parameter is specified.",
+        Remarks = "Retrieves the list item with ID 1 from from the Tasks list",
         SortOrder = 2)]
     [CmdletExample(
         Code = "PS:> Get-PnPListItem -List Tasks -UniqueId bd6c5b3b-d960-4ee7-a02c-85dc6cd78cc3",
-        Remarks = "Retrieves the list item with unique id bd6c5b3b-d960-4ee7-a02c-85dc6cd78cc3 from from the tasks lists. This parameter is ignored if the Query parameter is specified.",
+        Remarks = "Retrieves the list item with unique id bd6c5b3b-d960-4ee7-a02c-85dc6cd78cc3 from from the tasks lists",
         SortOrder = 3)]
     [CmdletExample(
         Code = "PS:> (Get-PnPListItem -List Tasks -Fields \"Title\",\"GUID\").FieldValues",
-        Remarks = "Retrieves all list items, but only includes the values of the Title and GUID fields in the list item object. This parameter is ignored if the Query parameter is specified.",
+        Remarks = "Retrieves all list items, but only includes the values of the Title and GUID fields in the list item object",
         SortOrder = 4)]
     [CmdletExample(
         Code = "PS:> Get-PnPListItem -List Tasks -Query \"<View><Query><Where><Eq><FieldRef Name='GUID'/><Value Type='Guid'>bd6c5b3b-d960-4ee7-a02c-85dc6cd78cc3</Value></Eq></Where></Query></View>\"",
-        Remarks = "Retrieves all list items based on the CAML query specified.",
+        Remarks = "Retrieves all list items based on the CAML query specified",
         SortOrder = 5)]
     [CmdletExample(
         Code = "PS:> Get-PnPListItem -List Tasks -PageSize 1000",
-        Remarks = "Retrieves all list items from the Tasks list in pages of 1000 items. This parameter is ignored if the Query parameter is specified.",
+        Remarks = "Retrieves all list items from the Tasks list in pages of 1000 items",
         SortOrder = 6)]
     [CmdletExample(
         Code = "PS:> Get-PnPListItem -List Tasks -PageSize 1000 -ScriptBlock { Param($items) $items.Context.ExecuteQuery() } | % { $_.BreakRoleInheritance($true, $true) }",
-        Remarks = "Retrieves all list items from the Tasks list in pages of 1000 items and breaks permission inheritance on each item.",
+        Remarks = "Retrieves all list items from the Tasks list in pages of 1000 items and breaks permission inheritance on each item",
         SortOrder = 7)]
     public class GetListItem : PnPWebCmdlet
     {

--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -27,7 +27,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Remarks = "Retrieves the list item with unique id bd6c5b3b-d960-4ee7-a02c-85dc6cd78cc3 from from the tasks lists. This parameter is ignored if the Query parameter is specified.",
         SortOrder = 3)]
     [CmdletExample(
-        Code = "PS:> Get-PnPListItem -List Tasks -Fields \"Title\",\"GUID\"",
+        Code = "PS:> (Get-PnPListItem -List Tasks -Fields \"Title\",\"GUID\").FieldValues",
         Remarks = "Retrieves all list items, but only includes the values of the Title and GUID fields in the list item object. This parameter is ignored if the Query parameter is specified.",
         SortOrder = 4)]
     [CmdletExample(


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [X] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Changed example on using -Fields argument as it isn't clear nor logical how to use the fields. The sample showed:

`Get-PnPListItem -List Tasks -Fields \"Title\",\"GUID\"`

Most logical would then be to expect to be able to pipe it to | select Title,GUID, but that doesn't work. Also another logical expectation would be to be able to assign the output to a variable and use it as a property on there, which also doesn't work.

Only way I found to be able to access the fields requested through the -Fields argument is to get them from the .FieldValues property on the result, thus this would be an example where you actually see what you retrieve:

`(Get-PnPListItem -List Tasks -Fields \"Title\",\"GUID\").FieldValues`

Therefore the sample update to show an end to end sample of how to make use of -Fields.