### PR TITLE
Fixes inconsistencies in Add-PnPCustomAction cmdlet parameters

### DIFF
--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -61,12 +61,18 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         public string CommandUIExtension = string.Empty;
 
         [Parameter(Mandatory = false, HelpMessage = "The identifier of the object associated with the custom action.", ParameterSetName = "Default")]
+#if !ONPREMISES
+        [Parameter(Mandatory = false, HelpMessage = "The identifier of the object associated with the custom action.", ParameterSetName = "ClientSideComponentId")]
+#endif
         public string RegistrationId = string.Empty;
 
         [Parameter(Mandatory = false, HelpMessage = "A string array that contain the permissions needed for the custom action", ParameterSetName = "Default")]
         public PermissionKind[] Rights;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifies the type of object associated with the custom action", ParameterSetName = "Default")]
+#if !ONPREMISES
+        [Parameter(Mandatory = false, HelpMessage = "Specifies the type of object associated with the custom action", ParameterSetName = "ClientSideComponentId")]
+#endif
         public UserCustomActionRegistrationType RegistrationType;
 
         [Parameter(Mandatory = false, HelpMessage = "The scope of the CustomAction to add to. Either Web or Site; defaults to Web. 'All' is not valid for this command.", ParameterSetName = "Default")]
@@ -75,7 +81,7 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         [Parameter(Mandatory = true, HelpMessage = "The Client Side Component Id of the custom action", ParameterSetName = "ClientSideComponentId")]
         public GuidPipeBind ClientSideComponentId;
 
-        [Parameter(Mandatory = true, HelpMessage = "The Client Side Component Properties of the custom action. Specify values as a json string : \"{Property1 : 'Value1', Property2: 'Value2'}\"", ParameterSetName = "ClientSideComponentId")]
+        [Parameter(Mandatory = false, HelpMessage = "The Client Side Component Properties of the custom action. Specify values as a json string : \"{Property1 : 'Value1', Property2: 'Value2'}\"", ParameterSetName = "ClientSideComponentId")]
         public string ClientSideComponentProperties;
 #endif
         protected override void ExecuteCmdlet()
@@ -119,6 +125,16 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
                     ClientSideComponentId = ClientSideComponentId.Id,
                     ClientSideComponentProperties = ClientSideComponentProperties
                 };
+
+                if (MyInvocation.BoundParameters.ContainsKey("RegistrationId"))
+                {
+                    ca.RegistrationId = RegistrationId;
+                }
+
+                if (MyInvocation.BoundParameters.ContainsKey("RegistrationType"))
+                {
+                    ca.RegistrationType = RegistrationType;
+                }
 #endif
             }
 

--- a/Documentation/AddPnPCustomAction.md
+++ b/Documentation/AddPnPCustomAction.md
@@ -4,6 +4,18 @@ Adds a custom action to a web
 ```powershell
 Add-PnPCustomAction -Name <String>
                     -Title <String>
+                    -Location <String>
+                    -ClientSideComponentId <GuidPipeBind>
+                    [-RegistrationId <String>]
+                    [-RegistrationType <UserCustomActionRegistrationType>]
+                    [-ClientSideComponentProperties <String>]
+                    [-Web <WebPipeBind>]
+```
+
+
+```powershell
+Add-PnPCustomAction -Name <String>
+                    -Title <String>
                     -Description <String>
                     -Group <String>
                     -Location <String>
@@ -19,26 +31,16 @@ Add-PnPCustomAction -Name <String>
 ```
 
 
-```powershell
-Add-PnPCustomAction -Name <String>
-                    -Title <String>
-                    -Location <String>
-                    -ClientSideComponentId <GuidPipeBind>
-                    -ClientSideComponentProperties <String>
-                    [-Web <WebPipeBind>]
-```
-
-
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
 |ClientSideComponentId|GuidPipeBind|True|The Client Side Component Id of the custom action|
-|ClientSideComponentProperties|String|True|The Client Side Component Properties of the custom action. Specify values as a json string : "{Property1 : 'Value1', Property2: 'Value2'}"|
 |Description|String|True|The description of the custom action|
 |Group|String|True|The group where this custom action needs to be added like 'SiteActions'|
 |Location|String|True|The actual location where this custom action need to be added like 'CommandUI.Ribbon'|
 |Name|String|True|The name of the custom action|
 |Title|String|True|The title of the custom action|
+|ClientSideComponentProperties|String|False|The Client Side Component Properties of the custom action. Specify values as a json string : "{Property1 : 'Value1', Property2: 'Value2'}"|
 |CommandUIExtension|String|False|XML fragment that determines user interface properties of the custom action|
 |ImageUrl|String|False|The URL of the image associated with the custom action|
 |RegistrationId|String|False|The identifier of the object associated with the custom action.|


### PR DESCRIPTION

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
The Add-PnPCustomAction cmdlet allows to add a custom action to associate with SPFx extensions through the ClientSideComponentId.
- The ClientSideComponentProperties, however, are not required
- For the ListviewCommandSet extension, we need to set the RegistrationId and RegistrationType parameters that were not included in the ParameterSet.

This PR fixes those two "issues"
