### PR TITLE
Allow remove all eventreceivers with Remove-PnPEventReceiver

### DIFF
--- a/Commands/Events/RemoveEventReceiver.cs
+++ b/Commands/Events/RemoveEventReceiver.cs
@@ -2,61 +2,115 @@
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using System.Collections.Generic;
 
 namespace SharePointPnP.PowerShell.Commands.Events
 {
     [Cmdlet(VerbsCommon.Remove, "PnPEventReceiver", SupportsShouldProcess = true)]
     [CmdletHelp("Removes/unregisters a specific event receiver",
-        Category = CmdletHelpCategory.EventReceivers)]
-    [CmdletExample(
-      Code = @"PS:> Remove-PnPEventReceiver -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
-      Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the current web", SortOrder = 1)]
-    [CmdletExample(
-      Code = @"PS:> Remove-PnPEventReceiver -List ProjectList -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
-      Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the list with name ""ProjectList""", SortOrder = 2)]
+                Category = CmdletHelpCategory.EventReceivers)]
+    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
+                   Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the current web", 
+                   SortOrder = 1)]
+    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -List ProjectList -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
+                   Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the list with name ""ProjectList""", 
+                   SortOrder = 2)]
+    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -List ProjectList",
+                   Remarks = @"This will remove all event receivers from the list with name ""ProjectList""",
+                   SortOrder = 3)]
+    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver",
+                   Remarks = @"This will remove all event receivers from the current site",
+                   SortOrder = 4)]
     public class RemoveEventReceiver : PnPWebCmdlet
     {
-        [Parameter(Mandatory = true, HelpMessage = "The Guid of the event receiver on the list")]
+        [Parameter(Mandatory = false, HelpMessage = "The Guid of the event receiver on the list")]
         public GuidPipeBind Identity;
 
-        [Parameter(Mandatory = false, ParameterSetName="List", HelpMessage = "The list object from where to get the event receiver object")]
+        [Parameter(Mandatory = false, ParameterSetName="List", HelpMessage = "The list object from where to remove the event receiver object")]
         public ListPipeBind List;
 
-        [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
+        [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question")]
         public SwitchParameter Force;
 
         protected override void ExecuteCmdlet()
         {
+            // Keep a list with all event receivers to remove for better performance and to avoid the collection changing when removing an item in the collection
+            var eventReceiversToDelete = new List<EventReceiverDefinition>();
+
             if (ParameterSetName == "List")
             {
                 var list = List.GetList(SelectedWeb);
 
-                if (Force || ShouldContinue(Properties.Resources.RemoveEventReceiver, Properties.Resources.Confirm))
+                if (MyInvocation.BoundParameters.ContainsKey("Identity"))
                 {
                     var eventReceiver = list.GetEventReceiverById(Identity.Id);
-                    if(eventReceiver != null)
+                    if (eventReceiver != null)
                     {
-                        eventReceiver.DeleteObject();
-                        ClientContext.ExecuteQueryRetry();
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, $"List '{list.Title}'"), Properties.Resources.Confirm))
+                        {
+                            eventReceiversToDelete.Add(eventReceiver);
+                        }
                     }
+                }
+                else
+                {
+                    var eventReceivers = list.EventReceivers;
+                    SelectedWeb.Context.Load(eventReceivers);
+                    SelectedWeb.Context.ExecuteQueryRetry();
+
+                    foreach (var eventReceiver in eventReceivers)
+                    {
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, $"List '{list.Title}'"), Properties.Resources.Confirm))
+                        {
+                            eventReceiversToDelete.Add(eventReceiver);
+                        }
+                    }
+                    ClientContext.ExecuteQueryRetry();
                 }
             }
             else
             {
-                if (Force || ShouldContinue(Properties.Resources.RemoveEventReceiver, Properties.Resources.Confirm))
+                if (MyInvocation.BoundParameters.ContainsKey("Identity"))
                 {
                     var eventReceiver = SelectedWeb.GetEventReceiverById(Identity.Id);
                     if (eventReceiver != null)
                     {
-                        eventReceiver.DeleteObject();
-                        ClientContext.ExecuteQueryRetry();
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, "Web"), Properties.Resources.Confirm))
+                        {
+                            eventReceiversToDelete.Add(eventReceiver);
+                        }
+                    }
+                }
+                else
+                {
+                    var eventReceivers = SelectedWeb.EventReceivers;
+                    SelectedWeb.Context.Load(eventReceivers);
+                    SelectedWeb.Context.ExecuteQueryRetry();
+
+                    foreach (var eventReceiver in eventReceivers)
+                    {
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, "Web"), Properties.Resources.Confirm))
+                        {
+                            eventReceiversToDelete.Add(eventReceiver);
+                        }
                     }
                 }
             }
+
+            if (eventReceiversToDelete.Count == 0)
+            {
+                WriteVerbose("No Event Receivers to remove");
+                return;
+            }
+
+            for(var x = 0; x < eventReceiversToDelete.Count; x++)
+            {
+                WriteVerbose($"Removing Event Receiver with Id {eventReceiversToDelete[x].ReceiverId} named {eventReceiversToDelete[x].ReceiverName}");
+                eventReceiversToDelete[x].DeleteObject();
+            }
+            SelectedWeb.Context.ExecuteQueryRetry();
         }
-
     }
-
 }
 
 

--- a/Commands/Properties/Resources.Designer.cs
+++ b/Commands/Properties/Resources.Designer.cs
@@ -369,7 +369,7 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove event receiver?.
+        ///   Looks up a localized string similar to Remove event receiver named &apos;{0}&apos; with id &apos;{1}&apos; from {2}?.
         /// </summary>
         internal static string RemoveEventReceiver {
             get {

--- a/Commands/Properties/Resources.resx
+++ b/Commands/Properties/Resources.resx
@@ -169,7 +169,7 @@
     <value>Remove custom action?</value>
   </data>
   <data name="RemoveEventReceiver" xml:space="preserve">
-    <value>Remove event receiver?</value>
+    <value>Remove event receiver named '{0}' with id '{1}' from {2}?</value>
   </data>
   <data name="RemoveJavaScript0" xml:space="preserve">
     <value>Remove JavaScript ('{0}')?</value>


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Made it possible to not specify an Identity which will then go through each event receiver and ask if it should be removed, minor code cleanup, allowed usage of -Confirm to bypass confirmation question. Left -Force in place for backwards compatibility. Made the confirmation question mention clearly which event receiver is about to be deleted. Updated samples and help text.