### PR TITLE
Introduced EventReceiverPipeBind

### DIFF
--- a/Commands/Admin/GetTimeZoneId.cs
+++ b/Commands/Admin/GetTimeZoneId.cs
@@ -19,8 +19,7 @@ namespace SharePointPnP.PowerShell.Commands
     public class GetTimeZoneId : PSCmdlet
     {
         [Parameter(Mandatory = false, Position = 0, HelpMessage = "A string to search for like 'Stockholm'")]
-        public
-            string Match;
+        public string Match;
 
         protected override void ProcessRecord()
         {

--- a/Commands/Base/PipeBinds/EventReceiverPipeBind.cs
+++ b/Commands/Base/PipeBinds/EventReceiverPipeBind.cs
@@ -44,5 +44,41 @@ namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
         {
             return Name ?? Id.ToString();
         }
+
+        internal EventReceiverDefinition GetEventReceiverOnWeb(Web web)
+        {
+            if (_eventReceiverDefinition != null)
+            {
+                return _eventReceiverDefinition;
+            }
+
+            if(_id != Guid.Empty)
+            {
+                return web.GetEventReceiverById(_id);
+            }
+            else if (!string.IsNullOrEmpty(Name))
+            {
+                return web.GetEventReceiverByName(Name);
+            }
+            return null;
+        }
+
+        internal EventReceiverDefinition GetEventReceiverOnList(List list)
+        {
+            if (_eventReceiverDefinition != null)
+            {
+                return _eventReceiverDefinition;
+            }
+
+            if (_id != Guid.Empty)
+            {
+                return list.GetEventReceiverById(_id);
+            }
+            else if (!string.IsNullOrEmpty(Name))
+            {
+                return list.GetEventReceiverByName(Name);
+            }
+            return null;
+        }
     }
 }

--- a/Commands/Base/PipeBinds/EventReceiverPipeBind.cs
+++ b/Commands/Base/PipeBinds/EventReceiverPipeBind.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.SharePoint.Client;
+using System;
+
+namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
+{
+    public sealed class EventReceiverPipeBind
+    {
+        private readonly EventReceiverDefinition _eventReceiverDefinition;
+        private readonly Guid _id;
+        private readonly string _name;
+
+        public EventReceiverPipeBind()
+        {
+            _eventReceiverDefinition = null;
+            _id = Guid.Empty;
+            _name = string.Empty;
+        }
+
+        public EventReceiverPipeBind(EventReceiverDefinition eventReceiverDefinition)
+        {
+            _eventReceiverDefinition = eventReceiverDefinition;
+        }
+
+        public EventReceiverPipeBind(Guid guid)
+        {
+            _id = guid;
+        }
+
+        public EventReceiverPipeBind(string id)
+        {
+            if (!Guid.TryParse(id, out _id))
+            {
+                _name = id;
+            }
+        }
+
+        public Guid Id => _id;
+
+        public EventReceiverDefinition EventReceiver => _eventReceiverDefinition;
+
+        public string Name => _name;
+
+        public override string ToString()
+        {
+            return Name ?? Id.ToString();
+        }
+    }
+}

--- a/Commands/Events/GetEventReceiver.cs
+++ b/Commands/Events/GetEventReceiver.cs
@@ -16,19 +16,25 @@ namespace SharePointPnP.PowerShell.Commands.Events
       Remarks = @"This will return all registered event receivers on the current web", SortOrder = 1)]
     [CmdletExample(
       Code = @"PS:> Get-PnPEventReceiver -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
-      Remarks = @"This will return a specific registered event receiver from the current web", SortOrder = 2)]
+      Remarks = @"This will return the event receiver with the provided ReceiverId ""fb689d0e-eb99-4f13-beb3-86692fd39f22"" from the current web", SortOrder = 2)]
+    [CmdletExample(
+      Code = @"PS:> Get-PnPEventReceiver -Identity MyReceiver",
+      Remarks = @"This will return the event receiver with the provided ReceiverName ""MyReceiver"" from the current web", SortOrder = 3)]
     [CmdletExample(
       Code = @"PS:> Get-PnPEventReceiver -List ""ProjectList""",
-      Remarks = @"This will return all registered event receivers in the list with the name ProjectList", SortOrder = 3)]
+      Remarks = @"This will return all registered event receivers in the provided ""ProjectList"" list", SortOrder = 4)]
     [CmdletExample(
       Code = @"PS:> Get-PnPEventReceiver -List ""ProjectList"" -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
-      Remarks = @"This will return a specific registered event receiver in the list with the name ProjectList", SortOrder = 4)]
+      Remarks = @"This will return the event receiver in the provided ""ProjectList"" list with with the provided ReceiverId ""fb689d0e-eb99-4f13-beb3-86692fd39f22""", SortOrder = 5)]
+    [CmdletExample(
+      Code = @"PS:> Get-PnPEventReceiver -List ""ProjectList"" -Identity MyReceiver",
+      Remarks = @"This will return the event receiver in the ""ProjectList"" list with the provided ReceiverName ""MyReceiver""", SortOrder = 5)]
     public class GetEventReceiver : PnPWebRetrievalsCmdlet<EventReceiverDefinition>
     {
         [Parameter(Mandatory = false, ParameterSetName = "List", HelpMessage = "The list object from which to get the event receiver object")]
         public ListPipeBind List;
 
-        [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "The Guid of the event receiver on the list")]
+        [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "The Guid of the event receiver")]
         public EventReceiverPipeBind Identity;
 
         protected override void ExecuteCmdlet()
@@ -39,7 +45,7 @@ namespace SharePointPnP.PowerShell.Commands.Events
 
                 if (list != null)
                 {
-                    if (Identity == null)
+                    if (!MyInvocation.BoundParameters.ContainsKey("Identity"))
                     {
                         var query = ClientContext.LoadQuery(list.EventReceivers);
                         ClientContext.ExecuteQueryRetry();
@@ -47,13 +53,13 @@ namespace SharePointPnP.PowerShell.Commands.Events
                     }
                     else
                     {
-                        WriteObject(list.GetEventReceiverById(Identity.Id));
+                        WriteObject(Identity.GetEventReceiverOnList(list));
                     }
                 }
             }
             else
             {
-                if (Identity == null)
+                if (!MyInvocation.BoundParameters.ContainsKey("Identity"))
                 {
                     var query = ClientContext.LoadQuery(SelectedWeb.EventReceivers);
                     ClientContext.ExecuteQueryRetry();
@@ -61,12 +67,9 @@ namespace SharePointPnP.PowerShell.Commands.Events
                 }
                 else
                 {
-                    WriteObject(SelectedWeb.GetEventReceiverById(Identity.Id));
+                    WriteObject(Identity.GetEventReceiverOnWeb(SelectedWeb));
                 }
             }
-
         }
     }
 }
-
-

--- a/Commands/Events/GetEventReceiver.cs
+++ b/Commands/Events/GetEventReceiver.cs
@@ -28,8 +28,8 @@ namespace SharePointPnP.PowerShell.Commands.Events
         [Parameter(Mandatory = false, ParameterSetName = "List", HelpMessage = "The list object from which to get the event receiver object")]
         public ListPipeBind List;
 
-        [Parameter(Mandatory = false, HelpMessage = "The Guid of the event receiver on the list")]
-        public GuidPipeBind Identity;
+        [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "The Guid of the event receiver on the list")]
+        public EventReceiverPipeBind Identity;
 
         protected override void ExecuteCmdlet()
         {

--- a/Commands/Events/RemoveEventReceiver.cs
+++ b/Commands/Events/RemoveEventReceiver.cs
@@ -10,17 +10,23 @@ namespace SharePointPnP.PowerShell.Commands.Events
     [CmdletHelp("Removes/unregisters a specific event receiver",
                 Category = CmdletHelpCategory.EventReceivers)]
     [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
-                   Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the current web", 
+                   Remarks = @"This will remove the event receiver with ReceiverId ""fb689d0e-eb99-4f13-beb3-86692fd39f22"" from the current web", 
                    SortOrder = 1)]
     [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -List ProjectList -Identity fb689d0e-eb99-4f13-beb3-86692fd39f22",
-                   Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the list with name ""ProjectList""", 
+                   Remarks = @"This will remove the event receiver with ReceiverId ""fb689d0e-eb99-4f13-beb3-86692fd39f22"" from the ""ProjectList"" list", 
                    SortOrder = 2)]
-    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -List ProjectList",
-                   Remarks = @"This will remove all event receivers from the list with name ""ProjectList""",
+    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -List ProjectList -Identity MyReceiver",
+                   Remarks = @"This will remove the event receiver with ReceiverName ""MyReceiver"" from the ""ProjectList"" list",
                    SortOrder = 3)]
+    [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver -List ProjectList",
+                   Remarks = @"This will remove all event receivers from the ""ProjectList"" list",
+                   SortOrder = 4)]
     [CmdletExample(Code = @"PS:> Remove-PnPEventReceiver",
                    Remarks = @"This will remove all event receivers from the current site",
-                   SortOrder = 4)]
+                   SortOrder = 5)]
+    [CmdletExample(Code = @"PS:> Get-PnPEventReceiver | ? ReceiverUrl -Like ""*azurewebsites.net*"" | Remove-PnPEventReceiver",
+                   Remarks = @"This will remove all event receivers from the current site which are pointing to a service hosted on Azure Websites",
+                   SortOrder = 6)]
     public class RemoveEventReceiver : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The Guid of the event receiver on the list")]
@@ -43,10 +49,10 @@ namespace SharePointPnP.PowerShell.Commands.Events
 
                 if (MyInvocation.BoundParameters.ContainsKey("Identity"))
                 {
-                    var eventReceiver = list.GetEventReceiverById(Identity.Id);
+                    var eventReceiver = Identity.GetEventReceiverOnList(list);
                     if (eventReceiver != null)
                     {
-                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, $"List '{list.Title}'"), Properties.Resources.Confirm))
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId), Properties.Resources.Confirm))
                         {
                             eventReceiversToDelete.Add(eventReceiver);
                         }
@@ -60,7 +66,7 @@ namespace SharePointPnP.PowerShell.Commands.Events
 
                     foreach (var eventReceiver in eventReceivers)
                     {
-                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, $"List '{list.Title}'"), Properties.Resources.Confirm))
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId), Properties.Resources.Confirm))
                         {
                             eventReceiversToDelete.Add(eventReceiver);
                         }
@@ -72,10 +78,10 @@ namespace SharePointPnP.PowerShell.Commands.Events
             {
                 if (MyInvocation.BoundParameters.ContainsKey("Identity"))
                 {
-                    var eventReceiver = SelectedWeb.GetEventReceiverById(Identity.Id);
+                    var eventReceiver = Identity.GetEventReceiverOnWeb(SelectedWeb);
                     if (eventReceiver != null)
                     {
-                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, "Web"), Properties.Resources.Confirm))
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId), Properties.Resources.Confirm))
                         {
                             eventReceiversToDelete.Add(eventReceiver);
                         }
@@ -89,7 +95,7 @@ namespace SharePointPnP.PowerShell.Commands.Events
 
                     foreach (var eventReceiver in eventReceivers)
                     {
-                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId, "Web"), Properties.Resources.Confirm))
+                        if (Force || (MyInvocation.BoundParameters.ContainsKey("Confirm") && !bool.Parse(MyInvocation.BoundParameters["Confirm"].ToString())) || ShouldContinue(string.Format(Properties.Resources.RemoveEventReceiver, eventReceiver.ReceiverName, eventReceiver.ReceiverId), Properties.Resources.Confirm))
                         {
                             eventReceiversToDelete.Add(eventReceiver);
                         }

--- a/Commands/Events/RemoveEventReceiver.cs
+++ b/Commands/Events/RemoveEventReceiver.cs
@@ -16,8 +16,8 @@ namespace SharePointPnP.PowerShell.Commands.Events
       Remarks = @"This will remove an event receiver with id fb689d0e-eb99-4f13-beb3-86692fd39f22 from the list with name ""ProjectList""", SortOrder = 2)]
     public class RemoveEventReceiver : PnPWebCmdlet
     {
-        [Parameter(Mandatory = true, HelpMessage = "The Guid of the event receiver on the list")]
-        public GuidPipeBind Identity;
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The Guid of the event receiver on the list")]
+        public EventReceiverPipeBind Identity;
 
         [Parameter(Mandatory = false, ParameterSetName="List", HelpMessage = "The list object from where to get the event receiver object")]
         public ListPipeBind List;

--- a/Commands/Properties/AssemblyInfo.cs
+++ b/Commands/Properties/AssemblyInfo.cs
@@ -44,6 +44,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.17.1708.1")]
-[assembly: AssemblyFileVersion("2.17.1708.1")]
+[assembly: AssemblyVersion("2.18.1709.0")]
+[assembly: AssemblyFileVersion("2.18.1709.0")]
 [assembly: InternalsVisibleTo("SharePointPnP.PowerShell.Tests")]

--- a/Commands/Properties/Resources.Designer.cs
+++ b/Commands/Properties/Resources.Designer.cs
@@ -369,7 +369,7 @@ namespace SharePointPnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove event receiver named &apos;{0}&apos; with id &apos;{1}&apos; from {2}?.
+        ///   Looks up a localized string similar to Remove event receiver named &apos;{0}&apos; with id &apos;{1}&apos;?.
         /// </summary>
         internal static string RemoveEventReceiver {
             get {

--- a/Commands/Properties/Resources.resx
+++ b/Commands/Properties/Resources.resx
@@ -169,7 +169,7 @@
     <value>Remove custom action?</value>
   </data>
   <data name="RemoveEventReceiver" xml:space="preserve">
-    <value>Remove event receiver named '{0}' with id '{1}' from {2}?</value>
+    <value>Remove event receiver named '{0}' with id '{1}'?</value>
   </data>
   <data name="RemoveJavaScript0" xml:space="preserve">
     <value>Remove JavaScript ('{0}')?</value>

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -410,6 +410,7 @@
     <Compile Include="Base\PipeBinds\GenericPropertiesPipeBind.cs" />
     <Compile Include="Base\PipeBinds\ClientSidePagePipeBind.cs" />
     <Compile Include="Base\PipeBinds\GenericObjectNameIdPipeBind.cs" />
+    <Compile Include="Base\PipeBinds\EventReceiverPipeBind.cs" />
     <Compile Include="Base\PipeBinds\WebhookSubscriptionPipeBind.cs" />
     <Compile Include="Base\PipeBinds\WebPartPipeBind.cs" />
     <Compile Include="Base\PipeBinds\UserPipeBind.cs" />

--- a/Documentation/GetPnPEventReceiver.md
+++ b/Documentation/GetPnPEventReceiver.md
@@ -3,13 +3,13 @@ Returns all or a specific event receiver
 ## Syntax
 ```powershell
 Get-PnPEventReceiver [-List <ListPipeBind>]
-                     [-Identity <GuidPipeBind>]
+                     [-Identity <EventReceiverPipeBind>]
                      [-Web <WebPipeBind>]
 ```
 
 
 ```powershell
-Get-PnPEventReceiver [-Identity <GuidPipeBind>]
+Get-PnPEventReceiver [-Identity <EventReceiverPipeBind>]
                      [-Web <WebPipeBind>]
                      [-Includes <String[]>]
 ```
@@ -21,7 +21,7 @@ Get-PnPEventReceiver [-Identity <GuidPipeBind>]
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
-|Identity|GuidPipeBind|False|The Guid of the event receiver on the list|
+|Identity|EventReceiverPipeBind|False|The Guid of the event receiver on the list|
 |Includes|String[]|False|Specify properties to include when retrieving objects from the server.|
 |List|ListPipeBind|False|The list object from which to get the event receiver object|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|

--- a/Documentation/RemovePnPEventReceiver.md
+++ b/Documentation/RemovePnPEventReceiver.md
@@ -2,7 +2,7 @@
 Removes/unregisters a specific event receiver
 ## Syntax
 ```powershell
-Remove-PnPEventReceiver -Identity <GuidPipeBind>
+Remove-PnPEventReceiver -Identity <EventReceiverPipeBind>
                         [-List <ListPipeBind>]
                         [-Force [<SwitchParameter>]]
                         [-Web <WebPipeBind>]
@@ -12,7 +12,7 @@ Remove-PnPEventReceiver -Identity <GuidPipeBind>
 ## Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
-|Identity|GuidPipeBind|True|The Guid of the event receiver on the list|
+|Identity|EventReceiverPipeBind|True|The Guid of the event receiver on the list|
 |Force|SwitchParameter|False|Specifying the Force parameter will skip the confirmation question.|
 |List|ListPipeBind|False|The list object from where to get the event receiver object|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Introduced EventReceiver PipeBind. Added ability to Get and Remove EventReceivers by their name instead of only their Id. Allowed passing results from a filtered Get-PnPEventReceiver to Remove-PnPEventReceiver to remove them. Had to remove the List\Web specification in the remove confirmation question as when passing a EventReceiver instance we don't know to which scope it belongs. Updated samples.

This PR complements PR https://github.com/SharePoint/PnP-PowerShell/pull/1088.

I couldn't get the .md file excluded. I didn't make any manual changes to it. Just ignore it.