### PR TITLE
Fixing PageName help issue in AddClientSidePage

### DIFF
--- a/Commands/ClientSidePages/AddClientSidePage.cs
+++ b/Commands/ClientSidePages/AddClientSidePage.cs
@@ -11,7 +11,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
     [CmdletHelp("Adds a Client-Side Page",
       Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPClientSidePage -PageName ""OurNewPage""",
+        Code = @"PS:> Add-PnPClientSidePage -Name ""OurNewPage""",
         Remarks = "Creates a new Client-Side page called 'OurNewPage'",
         SortOrder = 1)]
     public class AddClientSidePage : PnPWebCmdlet


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [X] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/1092

## What is in this Pull Request ? ##
Help text in AddClientSidePage.cs contained -PageName where it should be -Name as found by @kath561. This PR fixes that.