### PR TITLE
non-static connection support

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -190,14 +190,14 @@ dir",
             {
                 creds = Credentials.Credential;
             }
-
+            SPOnlineConnection connection = null;
             if (ParameterSetName == ParameterSet_TOKEN)
             {
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateSPOnlineConnection(new Uri(Url), Realm, AppId, AppSecret, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
+                connection = SPOnlineConnectionHelper.InstantiateSPOnlineConnection(new Uri(Url), Realm, AppId, AppSecret, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
             }
             else if (UseWebLogin)
             {
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateWebloginConnection(new Uri(Url), MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
+                connection = SPOnlineConnectionHelper.InstantiateWebloginConnection(new Uri(Url), MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
             }
             else if (UseAdfs)
             {
@@ -209,26 +209,26 @@ dir",
                     }
                 }
 
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), creds, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
+                connection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), creds, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
             }
 #if !ONPREMISES
             else if (ParameterSetName == ParameterSet_SPOManagement)
             {
-                ConnectNativAAD(SPOManagementClientId, SPOManagementRedirectUri);
+                connection = ConnectNativAAD(SPOManagementClientId, SPOManagementRedirectUri);
             }
             else if (ParameterSetName == ParameterSet_NATIVEAAD)
             {
-                ConnectNativAAD(ClientId, RedirectUri);
+                connection = ConnectNativAAD(ClientId, RedirectUri);
             }
             else if (ParameterSetName == ParameterSet_APPONLYAAD)
             {
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InitiateAzureADAppOnlyConnection(new Uri(Url), ClientId, Tenant, CertificatePath, CertificatePassword, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck, AzureEnvironment);
+                connection = SPOnlineConnectionHelper.InitiateAzureADAppOnlyConnection(new Uri(Url), ClientId, Tenant, CertificatePath, CertificatePassword, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck, AzureEnvironment);
             }
 #endif
 #if ONPREMISES
             else if (ParameterSetName == ParameterSet_HIGHTRUST)
             {
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateHighTrustConnection(Url, ClientId, HighTrustCertificatePath, HighTrustCertificatePassword, HighTrustCertificateIssuerId, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
+                connection = SPOnlineConnectionHelper.InstantiateHighTrustConnection(Url, ClientId, HighTrustCertificatePath, HighTrustCertificatePassword, HighTrustCertificateIssuerId, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
             }
 #endif
             else
@@ -241,10 +241,10 @@ dir",
                         creds = Host.UI.PromptForCredential(Properties.Resources.EnterYourCredentials, "", "", "");
                     }
                 }
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateSPOnlineConnection(new Uri(Url), creds, Host, CurrentCredentials, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck, AuthenticationMode);
+                connection = SPOnlineConnectionHelper.InstantiateSPOnlineConnection(new Uri(Url), creds, Host, CurrentCredentials, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck, AuthenticationMode);
             }
             WriteVerbose($"PnP PowerShell Cmdlets ({System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}): Connected to {Url}");
-
+            SPOnlineConnection.CurrentConnection = connection;
             if (CreateDrive && SPOnlineConnection.CurrentConnection.Context != null)
             {
                 var provider = SessionState.Provider.GetAll().FirstOrDefault(p => p.Name.Equals(SPOProvider.PSProviderName, StringComparison.InvariantCultureIgnoreCase));
@@ -259,10 +259,11 @@ dir",
                     SessionState.Drive.New(drive, "Global");
                 }
             }
+            WriteObject(connection);
         }
 
 #if !ONPREMISES
-        private void ConnectNativAAD(string clientId, string redirectUrl)
+        private SPOnlineConnection ConnectNativAAD(string clientId, string redirectUrl)
         {
             string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string configFolder = Path.Combine(appDataFolder, "SharePointPnP.PowerShell");
@@ -276,7 +277,7 @@ dir",
                     File.Delete(configFile);
                 }
             }
-            SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InitiateAzureADNativeApplicationConnection(
+            return SPOnlineConnectionHelper.InitiateAzureADNativeApplicationConnection(
                 new Uri(Url), clientId, new Uri(redirectUrl), MinimalHealthScore, RetryCount,
                 RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck, AzureEnvironment);
         }

--- a/Commands/Base/DisconnectSPOnline.cs
+++ b/Commands/Base/DisconnectSPOnline.cs
@@ -17,9 +17,12 @@ namespace SharePointPnP.PowerShell.Commands.Base
         SortOrder = 1)]
     public class DisconnectSPOnline : PSCmdlet
     {
+        [Parameter(Mandatory = false, HelpMessage = "Connection to be used by cmdlet")]
+        public SPOnlineConnection Connection = null;
+
         protected override void ProcessRecord()
         {
-            if (!DisconnectCurrentService())
+            if (!DisconnectCurrentService(Connection ?? SPOnlineConnection.CurrentConnection))
                 throw new InvalidOperationException(Properties.Resources.NoConnectionToDisconnect);
 
             var provider = SessionState.Provider.GetAll().FirstOrDefault(p => p.Name.Equals(SPOProvider.PSProviderName, StringComparison.InvariantCultureIgnoreCase));
@@ -34,11 +37,11 @@ namespace SharePointPnP.PowerShell.Commands.Base
             }
         }
 
-        internal static bool DisconnectCurrentService()
+        internal static bool DisconnectCurrentService(SPOnlineConnection connection)
         {
-            if (SPOnlineConnection.CurrentConnection == null)
+            if (connection == null)
                 return false;
-            SPOnlineConnection.CurrentConnection = null;
+            connection = null;
             return true;
         }
     }

--- a/Commands/Base/PnPCmdlet.cs
+++ b/Commands/Base/PnPCmdlet.cs
@@ -10,7 +10,10 @@ namespace SharePointPnP.PowerShell.Commands
 {
     public class PnPCmdlet : PSCmdlet
     {
-        public ClientContext ClientContext => SPOnlineConnection.CurrentConnection.Context;
+        public ClientContext ClientContext => Connection?.Context ?? SPOnlineConnection.CurrentConnection.Context;
+
+        [Parameter(Mandatory = false, HelpMessage = "Connection to be used by cmdlet")]
+        public SPOnlineConnection Connection = null;
 
         protected override void BeginProcessing()
         {
@@ -20,7 +23,7 @@ namespace SharePointPnP.PowerShell.Commands
             {
                 WriteWarning($"PnP Cmdlets starting with the SPO Prefix will be deprecated in the June 2017 release. Please update your scripts and use {MyInvocation.MyCommand.Name} instead.");
             }
-            if (SPOnlineConnection.CurrentConnection == null)
+            if (SPOnlineConnection.CurrentConnection == null && Connection == null)
             {
                 throw new InvalidOperationException(Resources.NoConnection);
             }


### PR DESCRIPTION
## Type ##
- [X] New Feature

## Related Issues? ##
PnP powershell cmdlets cannot be used in multi-threaded environment (e.g. Azure Functions) because of shared static connection object.

## What is in this Pull Request ? ##
New parameter to base pnpcmdlet to accept a connection object and use its ClientContext instead of static, if specified. Changes to Connect/Disconnect-PnPOnline to return/accept connection object. Not sure regarding Disconnect-PnPOnline though, it does not seem to do anything with connection, except setting static object reference to NULL, but does some changes to sessionstate config.

