### PR TITLE
Added -WithRightsAssigned to Get-PnPUser

### DIFF
--- a/Commands/Principals/GetUser.cs
+++ b/Commands/Principals/GetUser.cs
@@ -131,10 +131,5 @@ namespace SharePointPnP.PowerShell.Commands.Principals
                 WriteObject(user);
             }
         }
-
-        private object List<T>()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/Commands/Principals/GetUser.cs
+++ b/Commands/Principals/GetUser.cs
@@ -4,6 +4,8 @@ using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using System.Linq.Expressions;
 using System;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace SharePointPnP.PowerShell.Commands.Principals
 {
@@ -15,7 +17,7 @@ namespace SharePointPnP.PowerShell.Commands.Principals
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.user.aspx")]
     [CmdletExample(
         Code = @"PS:> Get-PnPUser",
-        Remarks = "Returns all users from the User Information List of the current site collection",
+        Remarks = "Returns all users from the User Information List of the current site collection regardless if they currently have rights to access the current site",
         SortOrder = 1)]
     [CmdletExample(
         Code = @"PS:> Get-PnPUser -Identity 23",
@@ -29,14 +31,25 @@ namespace SharePointPnP.PowerShell.Commands.Principals
         Code = @"PS:> Get-PnPUser | ? Email -eq ""user@tenant.onmicrosoft.com""",
         Remarks = "Returns the user with e-mail address user@tenant.onmicrosoft.com from the User Information List of the current site collection",
         SortOrder = 4)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPUser -WithRightsAssigned",
+        Remarks = "Returns only those users from the User Information List of the current site collection who currently have any kind of access rights given either directly to the user or Active Directory Group or given to the user or Active Directory Group via membership of a SharePoint Group to the current site",
+        SortOrder = 5)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPUser -WithRightsAssigned -Web subsite1",
+        Remarks = "Returns only those users from the User Information List of the current site collection who currently have any kind of access rights given either directly to the user or Active Directory Group or given to the user or Active Directory Group via membership of a SharePoint Group to subsite 'subsite1'",
+        SortOrder = 6)]
     public class GetUser : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0, HelpMessage = "User ID or login name")]
         public UserPipeBind Identity;
 
+        [Parameter(Mandatory = false, Position = 1, HelpMessage = "If provided, only users that currently have any kinds of access rights assigned to the current site collection will be returned. Otherwise all users, even those who previously had rights assigned, but not anymore at the moment, will be returned as the information is pulled from the User Information List. Only works if you don't provide an -Identity.")]
+        public SwitchParameter WithRightsAssigned;
+
         protected override void ExecuteCmdlet()
         {
-            var retrievalExpressions = new Expression<Func<User, object>>[] 
+            var retrievalExpressions = new Expression<Func<User, object>>[]
             {
                 u => u.Id,
                 u => u.Title,
@@ -60,10 +73,40 @@ namespace SharePointPnP.PowerShell.Commands.Principals
                     g => g.LoginName)
             };
 
-            if (Identity == null) {
-                SelectedWeb.Context.Load(SelectedWeb.SiteUsers, users => users.Include(retrievalExpressions));
-                SelectedWeb.Context.ExecuteQueryRetry();
-                WriteObject(SelectedWeb.SiteUsers, true);
+            if (Identity == null)
+            {
+                SelectedWeb.Context.Load(SelectedWeb.SiteUsers, u => u.Include(retrievalExpressions));
+
+                if (WithRightsAssigned)
+                {
+                    // Get all the role assignments and role definition bindings to be able to see which users have been given rights directly on the site level
+                    SelectedWeb.Context.Load(SelectedWeb.RoleAssignments, ac => ac.Include(a => a.RoleDefinitionBindings, a => a.Member));
+                    var usersWithDirectPermissions = SelectedWeb.SiteUsers.Where(u => SelectedWeb.RoleAssignments.Any(ra => ra.Member.LoginName == u.LoginName));
+
+                    // Get all the users contained in SharePoint Groups
+                    SelectedWeb.Context.Load(SelectedWeb.SiteGroups, sg => sg.Include(u => u.Users.Include(retrievalExpressions)));
+                    SelectedWeb.Context.ExecuteQueryRetry();
+
+                    var usersWithGroupPermissions = new List<User>();
+                    foreach (var group in SelectedWeb.SiteGroups)
+                    {
+                        // If they're in a SharePoint Group, they always have some kind of access rights, so add them all
+                        usersWithGroupPermissions.AddRange(group.Users);
+                    }
+
+                    // Merge the users with rights directly on the site level and those assigned rights through SharePoint Groups
+                    var allUsersWithPermissions = new List<User>(usersWithDirectPermissions.Count() + usersWithGroupPermissions.Count());
+                    allUsersWithPermissions.AddRange(usersWithDirectPermissions);
+                    allUsersWithPermissions.AddRange(usersWithGroupPermissions);
+
+                    // Filter out the users that have been given rights at both places so they will only be returned once
+                    WriteObject(allUsersWithPermissions.GroupBy(u => u.Id).Select(u => u.First()), true);
+                }
+                else
+                {
+                    SelectedWeb.Context.ExecuteQueryRetry();
+                    WriteObject(SelectedWeb.SiteUsers, true);
+                }
             }
             else
             {
@@ -80,12 +123,18 @@ namespace SharePointPnP.PowerShell.Commands.Principals
                 {
                     user = SelectedWeb.SiteUsers.GetByLoginName(Identity.Login);
                 }
-                if (user != null) {
+                if (user != null)
+                {
                     SelectedWeb.Context.Load(user, retrievalExpressions);
                     SelectedWeb.Context.ExecuteQueryRetry();
                 }
                 WriteObject(user);
             }
+        }
+
+        private object List<T>()
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Resubmit of https://github.com/SharePoint/PnP-PowerShell/pull/1112

## What is in this Pull Request ? ##
Added -WithRightsAssigned flag to Get-PnPUser to only return users that have any kind of access rights on the site as opposed to the regular Get-PnPUser which includes any user ever having had access to the site and still existing in the User Information List.