### PR TITLE
Added basetype to EnsureProperties

### DIFF
--- a/Commands/Lists/SetList.cs
+++ b/Commands/Lists/SetList.cs
@@ -101,7 +101,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                     isDirty = true;
                 }
 
-                list.EnsureProperties(l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden);
+                list.EnsureProperties(l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.BaseType);
 
                 var enableVersioning = list.EnableVersioning;
                 var enableMinorVersions = list.EnableMinorVersions;


### PR DESCRIPTION
## Type ##
- [X ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #860 

## What is in this Pull Request ? ##
Included BaseType when ensuring properties in Set-PnPList

BaseType is not including when getting list by guid, and therefore throws an exception when trying to find out if it's a list is or doclib.  