### PR TITLE
Do not suppress PipelineStoppedException

### DIFF
--- a/Commands/Base/PnPCmdlet.cs
+++ b/Commands/Base/PnPCmdlet.cs
@@ -100,7 +100,9 @@ namespace SharePointPnP.PowerShell.Commands
             }
             catch (System.Management.Automation.PipelineStoppedException)
             {
-                //swallow pipeline stopped exception
+                //don't swallow pipeline stopped exception
+                //it makes select-object work weird
+                throw;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix

## Related Issues? ##
Not sure

## What is in this Pull Request ? ##
I've noticed a small but annoying issue with cmdlets derived from PnPCmdlet. If cmdlet returns a collection of objects and piped with Select-Object with "First" parameter, then result of Select-Object is only written to console but not to variable. For example:
"$g = Get-PnPGroup | Select -First 1", will result in outputting first group object to console, but $g variable is not set.
I've found out that Select-Object with First parameter will eventually throw PipelineStoppedException (when specified amount of objects is written to pipeline) to make piped command stop execution. I guess that this behavior is not specific to Select-Object and may be used by other cmdlets as well. But when exception is caught in PnPCmdlet, pipeline behaves weirdly after that. It does not write resulting value to variable, but outputs it console. If exception is not caught and handled by environment then pipeline behaves normally and write output to variable.
Docs say: "Catching this exception is optional; if the cmdlet or providers chooses not to handle PipelineStoppedException and instead allow it to propagate to the Monad Engine's call to ProcessRecord, the Monad Engine will handle it properly." (https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.pipelinestoppedexception). So I guess that just catching and doing nothing is not "handling it properly", but did not find any guidance on how to handle the exception. 
Anyway I would propose not to suppress this exception, if it is not done for some particular reason of course. And would be great to hear if you have/find an explanation of this behavior. Thanks!

