### PR TITLE
Role definition

### DIFF
--- a/Commands/Site/AddRoleDefinition.cs
+++ b/Commands/Site/AddRoleDefinition.cs
@@ -55,6 +55,14 @@ namespace SharePointPnP.PowerShell.Commands.Site
                         }
                         var spBasePerm = clonePerm.BasePermissions;
                     }
+					
+					// Include and Exclude Flags
+					foreach (string flag in Include.Split(",")) {
+						spBasePerm.Set(flag)
+					}
+					foreach (string flag in Exclude.Split(",")) {
+						spBasePerm.Clear(flag)
+					}
 
                     // Create Role Definition
                     spRoleDef.Name = RoleName;

--- a/Commands/Site/AddRoleDefinition.cs
+++ b/Commands/Site/AddRoleDefinition.cs
@@ -1,0 +1,81 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using System.Collections.Generic;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Site
+{
+    [Cmdlet(VerbsCommon.Add, "PnPRoleDefinition")]
+    [CmdletHelp("Adds a Role Defintion (Permission Level) to the site collection in the current context",
+        DetailedDescription = "This command allows adding a custom Role Defintion (Permission Level) to the site collection in the current context. It does not replace or remove existing Role Definitions.",
+        Category = CmdletHelpCategory.Sites)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPRoleDefinition -RoleName ""CustomPerm""",
+        Remarks = @"Creates additional permission level with no permission flags enabled.", SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPRoleDefinition -RoleName ""NoDelete"" -Clone ""Contribute"" -Exclude ""DeleteListItems""",
+        Remarks = @"Creates additional permission level by cloning ""Contribute"" and removes flags ""DeleteListItems""", SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPRoleDefinition -RoleName ""AddOnly"" -Clone ""Contribute"" -Exclude ""DeleteListItems,EditListItems""",
+        Remarks = @"Creates additional permission level by cloning ""Contribute"" and removes flags ""DeleteListItems,EditListItems""", SortOrder = 3)]
+
+    public class AddSiteCollectionAdmin : PnPCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "Name of new permission level.")]
+        public string RoleName;
+
+        [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "Name of existing permission level to clone as base template.")]
+        public string Clone;
+
+        [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "Specifies permission flags(s) to enable.")]
+        public string Include;
+
+        [Parameter(Mandatory = false, ValueFromPipeline = true, HelpMessage = "Specifies permission flags(s) to disable.")]
+        public string Exclude;
+
+        protected override void ExecuteCmdlet()
+        {
+            // Validate user inputs
+            var roleDefinition = ClientContext.Site.RootWeb.RoleDefinitions.GetByName(RoleName);
+            ClientContext.Load(roleDefinition);
+            ClientContext.ExecuteQuery();
+            if (roleDefinition == null) {
+                try {
+                    // Prepare Role Definition Information
+                    var spRoleDef = new Microsoft.SharePoint.Client.RoleDefinitionCreationInformation();
+                    var spBasePerm = new Microsoft.SharePoint.Client.BasePermissions();
+
+                    if (Clone) {
+                        try {
+                            var clonePerm = ClientContext.Site.RootWeb.RoleDefinitions.GetByName(Clone);
+                        } catch {
+                            WriteWarning($"Unable to add Role Defintion as clone name cannot be found.  Will be skipped.");
+                            return;
+                        }
+                        var spBasePerm = clonePerm.BasePermissions;
+                    }
+
+                    // Create Role Definition
+                    spRoleDef.Name = RoleName;
+                    spRoleDef.Description = Description;
+                    spRoleDef.BasePermissions = spBasePerm;
+                    ClientContext.Site.RootWeb.RoleDefinitions.Add(spRoleDef);
+                    ClientContext.ExecuteQuery();
+
+                    WriteVerbose($"Role Definition (Permission Level) with the name $RoleName created");
+
+                    // Echo created object
+                    var roleDefinition = ClientContext.Site.RootWeb.RoleDefinitions.GetByName(RoleName);
+                    ClientContext.Load(roleDefinition);
+                    ClientContext.ExecuteQuery();
+                    roleDefinition;
+                } catch {
+
+                }
+            } else {
+                 WriteWarning($"Unable to add Role Defintion as name already in use.  Will be skipped.");
+            }
+        }
+    }
+}

--- a/Commands/Site/GetRoleDefinition.cs
+++ b/Commands/Site/GetRoleDefinition.cs
@@ -1,0 +1,26 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+
+namespace SharePointPnP.PowerShell.Commands.Site
+{
+    [Cmdlet(VerbsCommon.Get, "PnPRoleDefinition")]
+    [CmdletHelp("Get the Role Definitions of a site",
+        Category = CmdletHelpCategory.Sites,
+        OutputType = typeof(RoleDefinition),
+        OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.roledefinition.aspx")]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPRoleDefinition",
+        Remarks = "Gets the Role Definitions (Permission Levels) settings of the current site",
+        SortOrder = 1)]
+    public class GetRoleDefinition : PnPCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            var roleDefinitions = ClientContext.Site.RootWeb.roleDefinitions;
+            ClientContext.Load(roleDefinitions);
+            ClientContext.ExecuteQueryRetry();
+            WriteObject(roleDefinitions);
+        }
+    }
+}

--- a/Commands/Site/RemoveRoleDefinition.cs
+++ b/Commands/Site/RemoveRoleDefinition.cs
@@ -1,0 +1,44 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+
+namespace SharePointPnP.PowerShell.Commands.Site
+{
+    [Cmdlet(VerbsCommon.Remove, "PnPRoleDefinition")]
+    [CmdletHelp("Remove the Role Definitions of a site",
+        Category = CmdletHelpCategory.Sites,
+        OutputType = typeof(RoleDefinition),
+        OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.roledefinition.aspx")]
+    [CmdletExample(
+        Code = @"PS:> Remove-PnPRoleDefinition",
+        Remarks = "Removes the Role Definition (Permission Level) from the current site",
+        SortOrder = 1)]
+    public class RemoveRoleDefinition : PnPCmdlet
+    {
+		[Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "Specifies owner(s) to remove as site collection adminstrators. Can be both users and groups.")]
+		public string RoleName;	
+		
+        protected override void ExecuteCmdlet()
+        {
+            var roleDefinition = ClientContext.Site.RootWeb.RoleDefinitions.GetByName(RoleName);
+            ClientContext.Load(roleDefinition);
+            ClientContext.ExecuteQueryRetry();
+            if (roleDefinition != null) {
+                try
+                {
+                    roleDefinition.Delete();
+                    ClientContext.ExecuteQueryRetry();
+                    WriteVerbose("Removed Role Definition \"{RoleName}\"")
+                }
+                catch (ServerException e)
+                {
+                    WriteWarning($"Exception occurred while trying to remove the Role Definition: \"{e.Message}\". Will be skipped.");
+                }
+            }
+            else
+            {
+                WriteWarning($"Unable to remove Role Definition as it wasn't found. Will be skipped.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Created 2/4/2018 by @spjeff

## Type ##
- [ ] Bug Fix
- [X ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added 3 new cmdlets for RoleDefinition to manage custom Permission Levels via CSOM
* Add-PnPRoleDefinition
* Get-PnPRoleDefinition
* Remove-PnPRoleDefinition

### Guidance ###
Added 3 new cmdlets for RoleDefinition to manage custom Permission Levels via CSOM.   

Business users may need to expand the "Contribute" role with more tailor permissions for use cases like audit where delete cannot occur.   Running this cmdlet with "-Exclude" and -"Clone" can copy an existing permission level with reduces permissions available.

Flexibility to create extra permission levels gives control and clarity for business needs.  Automation in PowerShell provides the consistency and speed to support custom permission across a high number of sites.
