### PR TITLE
Added support to include remote file to AddFileToProvisioningTemplate

### DIFF
--- a/Commands/Provisioning/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/AddFileToProvisioningTemplate.cs
@@ -5,10 +5,18 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Utilities;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
 using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
 using PnPFileLevel = OfficeDevPnP.Core.Framework.Provisioning.Model.FileLevel;
 using SPFile = Microsoft.SharePoint.Client.File;
 
@@ -60,8 +68,12 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
         [Parameter(Mandatory = false, Position = 5, HelpMessage = "Set to overwrite in site, Defaults to true")]
         public SwitchParameter FileOverwrite = true;
 
-        [Parameter(Mandatory = false, Position = 4, HelpMessage = "Allows you to specify ITemplateProviderExtension to execute while loading the template.")]
+        [Parameter(Mandatory = false, Position = 6, HelpMessage = "Allows you to specify ITemplateProviderExtension to execute while loading the template.")]
         public ITemplateProviderExtension[] TemplateProviderExtensions;
+
+        [Parameter(Mandatory = false, Position = 7, ParameterSetName = "RemoteSourceFile", HelpMessage = "Specifies if webparts has to be exported when exporting a remote file")]
+        public SwitchParameter IncludeWebParts;
+
 
         protected override void ProcessRecord()
         {
@@ -81,7 +93,9 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
             }
             if (this.ParameterSetName == "RemoteSourceFile")
             {
-                SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+                SelectedWeb.EnsureProperties(w => w.Id, w => w.Url, w => w.ServerRelativeUrl);
+                ((ClientContext)SelectedWeb.Context).Site.EnsureProperties(s => s.Id, s => s.Url, s => s.ServerRelativeUrl);
+
                 var sourceUri = new Uri(SourceUrl, UriKind.RelativeOrAbsolute);
                 var serverRelativeUrl =
                     sourceUri.IsAbsoluteUri ? sourceUri.AbsolutePath :
@@ -89,7 +103,7 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
                     SelectedWeb.ServerRelativeUrl.TrimEnd('/') + "/" + SourceUrl;
 
                 var file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
-
+                ClientContext.Load(file, f => f.ServerRelativeUrl);
                 var fileName = file.EnsureProperty(f => f.Name);
                 var folderRelativeUrl = serverRelativeUrl.Substring(0, serverRelativeUrl.Length - fileName.Length - 1);
                 var folderWebRelativeUrl = HttpUtility.UrlKeyValueDecode(folderRelativeUrl.Substring(SelectedWeb.ServerRelativeUrl.TrimEnd('/').Length + 1));
@@ -103,12 +117,22 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
                         // and the stream provided by OpenBinaryDirect does not allow it
                         fi.Stream.CopyTo(ms);
                         ms.Position = 0;
-                        AddFileToTemplate(template, ms, folderWebRelativeUrl, fileName, folderWebRelativeUrl);
+                        var fileProperties = GetProperties(file, ms.ToArray());
+
+                        var webParts = IncludeWebParts ? ExtractWebParts(file) : null;
+                        AddFileToTemplate(
+                            template,
+                            ms,
+                            folderWebRelativeUrl,
+                            fileName,
+                            folderWebRelativeUrl,
+                            fileProperties,
+                            webParts
+                            );
                     }
                 }
                 catch (WebException exc)
                 {
-
                     WriteWarning($"Can't add file from url {serverRelativeUrl} : {exc}");
                 }
             }
@@ -131,7 +155,83 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
             }
         }
 
-        private void AddFileToTemplate(ProvisioningTemplate template, Stream fs, string folder, string fileName, string container)
+        private IEnumerable<WebPart> ExtractWebParts(SPFile file)
+        {
+            if (string.Compare(System.IO.Path.GetExtension(file.Name), ".aspx", true)==0)
+            {
+                foreach (var spwp in SelectedWeb.GetWebParts(file.ServerRelativeUrl))
+                {
+                    spwp.EnsureProperties(wp => wp.WebPart
+#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
+                , wp => wp.ZoneId
+#endif
+                );
+                    yield return new WebPart
+                    {
+                        Contents = Tokenize(SelectedWeb.GetWebPartXml(spwp.Id, file.ServerRelativeUrl)),
+                        Order = (uint)spwp.WebPart.ZoneIndex,
+                        Title = spwp.WebPart.Title,
+#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
+                        Zone = spwp.ZoneId
+#endif
+                    };
+                }
+            }
+            else
+            {
+                WriteWarning($"File {file.ServerRelativeUrl} is not a webpart page");
+            }
+        }
+
+        private string Tokenize(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+            //foreach (var list in lists)
+            //{
+            //    input = input.ReplaceCaseInsensitive(web.Url.TrimEnd('/') + "/" + list.GetWebRelativeUrl(), "{listurl:" + Regex.Escape(list.Title) + "}");
+            //    input = input.ReplaceCaseInsensitive(list.RootFolder.ServerRelativeUrl, "{listurl:" + Regex.Escape(list.Title)+ "}");
+            //}
+            return input.ReplaceCaseInsensitive(SelectedWeb.Url, "{site}")
+                .ReplaceCaseInsensitive(SelectedWeb.ServerRelativeUrl, "{site}")
+                .ReplaceCaseInsensitive(SelectedWeb.Id.ToString(), "{siteid}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.ServerRelativeUrl, "{sitecollection}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.Id.ToString(), "{sitecollectionid}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.Url, "{sitecollection}");
+        }
+
+        private Dictionary<string, string> GetProperties(SPFile file, byte[] rawContent)
+        {
+            if (string.Compare(System.IO.Path.GetExtension(file.Name), ".aspx", true) == 0)
+            {
+                var content = Encoding.UTF8.GetString(rawContent);
+
+                var propsMatch = Regex.Match(content, @"<SharePoint:CTFieldRefs.*?>(.*)</SharePoint:CTFieldRefs>", RegexOptions.Singleline);
+                if (propsMatch.Success)
+                {
+                    var xml = $"<wrapper xmlns:mso='mso' xmlns:msdt='msdt'>{propsMatch.Groups[1].Value}</wrapper>";
+                    var propsXml = XElement.Parse(xml);
+                    var xmlNsMgr = new XmlNamespaceManager(new NameTable());
+                    xmlNsMgr.AddNamespace("mso", "mso");
+                    xmlNsMgr.AddNamespace("msdt", "msdt");
+                    var propNodes = propsXml.XPathSelectElement("//mso:CustomDocumentProperties", xmlNsMgr);
+                    return propNodes.Elements().ToDictionary(
+                        n => n.Name.LocalName,
+                        n => Tokenize(n.Value)
+                        );
+                }
+            }
+            return null;
+        }
+
+        private void AddFileToTemplate(
+            ProvisioningTemplate template,
+            Stream fs,
+            string folder,
+            string fileName,
+            string container,
+            IDictionary<string, string> properties = null,
+            IEnumerable<WebPart> webParts = null
+            )
         {
             var source = !string.IsNullOrEmpty(container) ? (container + "/" + fileName) : fileName;
 
@@ -142,13 +242,25 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
                 ((ICommitableFileConnector)template.Connector).Commit();
             }
 
-            template.Files.Add(new OfficeDevPnP.Core.Framework.Provisioning.Model.File
+            var newFile = new OfficeDevPnP.Core.Framework.Provisioning.Model.File
             {
                 Src = source,
                 Folder = folder,
                 Level = FileLevel,
-                Overwrite = FileOverwrite,
-            });
+                Overwrite = FileOverwrite
+            };
+            if (properties != null)
+            {
+                foreach (var prop in properties)
+                {
+                    newFile.Properties.Add(prop.Key, prop.Value);
+                }
+            }
+            if (webParts != null)
+            {
+                newFile.WebParts.AddRange(webParts);
+            }
+            template.Files.Add(newFile);
 
             // Determine the output file name and path
             var outFileName = System.IO.Path.GetFileName(Path);

--- a/Commands/Provisioning/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/AddFileToProvisioningTemplate.cs
@@ -89,7 +89,8 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
                     SelectedWeb.ServerRelativeUrl.TrimEnd('/') + "/" + SourceUrl;
 
                 var file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
-                var fileName = SourceUrl.IndexOf("/") > 0 ? SourceUrl.Substring(SourceUrl.LastIndexOf('/') + 1) : SourceUrl;
+
+                var fileName = file.EnsureProperty(f => f.Name);
                 var folderRelativeUrl = serverRelativeUrl.Substring(0, serverRelativeUrl.Length - fileName.Length - 1);
                 var folderWebRelativeUrl = HttpUtility.UrlKeyValueDecode(folderRelativeUrl.Substring(SelectedWeb.ServerRelativeUrl.TrimEnd('/').Length + 1));
                 if (ClientContext.HasPendingRequest) ClientContext.ExecuteQuery();

--- a/Commands/Provisioning/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/AddFileToProvisioningTemplate.cs
@@ -74,7 +74,6 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
         [Parameter(Mandatory = false, Position = 7, ParameterSetName = "RemoteSourceFile", HelpMessage = "Specifies if webparts has to be exported when exporting a remote file")]
         public SwitchParameter IncludeWebParts;
 
-
         protected override void ProcessRecord()
         {
             if (!System.IO.Path.IsPathRooted(Path))
@@ -157,7 +156,7 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
 
         private IEnumerable<WebPart> ExtractWebParts(SPFile file)
         {
-            if (string.Compare(System.IO.Path.GetExtension(file.Name), ".aspx", true)==0)
+            if (string.Compare(System.IO.Path.GetExtension(file.Name), ".aspx", true) == 0)
             {
                 foreach (var spwp in SelectedWeb.GetWebParts(file.ServerRelativeUrl))
                 {
@@ -241,6 +240,12 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
             {
                 ((ICommitableFileConnector)template.Connector).Commit();
             }
+
+            var existing = template.Files.FirstOrDefault(f =>
+                f.Src == $"{container}/{fileName}"
+                && f.Folder == folder);
+            if(existing != null)
+            template.Files.Remove(existing);
 
             var newFile = new OfficeDevPnP.Core.Framework.Provisioning.Model.File
             {

--- a/Commands/Provisioning/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/AddFileToProvisioningTemplate.cs
@@ -1,15 +1,16 @@
-﻿using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
+﻿using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.Utilities;
+using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
-using System.Text;
-using System.Threading.Tasks;
+using System.Net;
+using PnPFileLevel = OfficeDevPnP.Core.Framework.Provisioning.Model.FileLevel;
+using SPFile = Microsoft.SharePoint.Client.File;
 
 namespace SharePointPnP.PowerShell.Commands.Provisioning
 {
@@ -32,23 +33,29 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -Source $sourceFilePath -Folder $targetFolder -Container $container",
        Remarks = "Adds a file to a PnP Provisioning Template with a custom container for the file",
        SortOrder = 4)]
-
-    public class AddFileToProvisioningTemplate : PSCmdlet
+    [CmdletExample(
+        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceUrl $urlOfFile",
+        Remarks = "Adds a file to a PnP Provisioning Template retrieved from the currently connected web",
+        SortOrder = 4)]
+    public class AddFileToProvisioningTemplate : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, HelpMessage = "Filename of the .PNP Open XML provisioning template to read from, optionally including full path.")]
         public string Path;
 
-        [Parameter(Mandatory = true, Position = 1, HelpMessage = "The file to add to the in-memory template, optionally including full path.")]
+        [Parameter(Mandatory = true, Position = 1, ParameterSetName = "LocalSourceFile", HelpMessage = "The file to add to the in-memory template, optionally including full path.")]
         public string Source;
 
-        [Parameter(Mandatory = true, Position = 2, HelpMessage = "The target Folder for the file to add to the in-memory template.")]
+        [Parameter(Mandatory = true, Position = 1, ParameterSetName = "RemoteSourceFile", HelpMessage = "The file to add to the in-memory template, specifying its url in the current connected Web.")]
+        public string SourceUrl;
+
+        [Parameter(Mandatory = true, Position = 2, ParameterSetName = "LocalSourceFile", HelpMessage = "The target Folder for the file to add to the in-memory template.")]
         public string Folder;
 
         [Parameter(Mandatory = false, Position = 3, HelpMessage = "The target Container for the file to add to the in-memory template, optional argument.")]
         public string Container;
 
         [Parameter(Mandatory = false, Position = 4, HelpMessage = "The level of the files to add. Defaults to Published")]
-        public FileLevel FileLevel = FileLevel.Published;
+        public PnPFileLevel FileLevel = PnPFileLevel.Published;
 
         [Parameter(Mandatory = false, Position = 5, HelpMessage = "Set to overwrite in site, Defaults to true")]
         public SwitchParameter FileOverwrite = true;
@@ -62,63 +69,104 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
             {
                 Path = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Path);
             }
-            if(!System.IO.Path.IsPathRooted(Source))
-            {
-                Source = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Source);
-            }
             // Load the template
-            var template = LoadProvisioningTemplate
-                .LoadProvisioningTemplateFromFile(Path,
-                TemplateProviderExtensions);
+            var template = LoadProvisioningTemplate.LoadProvisioningTemplateFromFile(
+                Path,
+                TemplateProviderExtensions
+                );
 
             if (template == null)
             {
                 throw new ApplicationException("Invalid template file!");
             }
-
-            // Load the file and add it to the .PNP file
-            using (var fs = new FileStream(Source, FileMode.Open, FileAccess.Read, FileShare.Read))
+            if (this.ParameterSetName == "RemoteSourceFile")
             {
-                Folder = Folder.Replace("\\", "/");
+                SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+                var sourceUri = new Uri(SourceUrl, UriKind.RelativeOrAbsolute);
+                var serverRelativeUrl =
+                    sourceUri.IsAbsoluteUri ? sourceUri.AbsolutePath :
+                    SourceUrl.StartsWith("/") ? SourceUrl :
+                    SelectedWeb.ServerRelativeUrl.TrimEnd('/') + "/" + SourceUrl;
 
-                var fileName = Source.IndexOf("\\") > 0 ? Source.Substring(Source.LastIndexOf("\\") + 1) : Source;
-                var container = !string.IsNullOrEmpty(Container) ? Container : string.Empty;
-                var source = !string.IsNullOrEmpty(container) ? (container + "/" + fileName) : fileName;
-
-                template.Connector.SaveFileStream(fileName, container, fs);
-
-                if (template.Connector is ICommitableFileConnector)
+                var file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
+                var fileName = SourceUrl.IndexOf("/") > 0 ? SourceUrl.Substring(SourceUrl.LastIndexOf('/') + 1) : SourceUrl;
+                var folderRelativeUrl = serverRelativeUrl.Substring(0, serverRelativeUrl.Length - fileName.Length - 1);
+                var folderWebRelativeUrl = HttpUtility.UrlKeyValueDecode(folderRelativeUrl.Substring(SelectedWeb.ServerRelativeUrl.TrimEnd('/').Length + 1));
+                if (ClientContext.HasPendingRequest) ClientContext.ExecuteQuery();
+                try
                 {
-                    ((ICommitableFileConnector)template.Connector).Commit();
+                    using (var fi = SPFile.OpenBinaryDirect(ClientContext, serverRelativeUrl))
+                    using (var ms = new MemoryStream())
+                    {
+                        // We are using a temporary memory stream because the file connector is seeking in the stream
+                        // and the stream provided by OpenBinaryDirect does not allow it
+                        fi.Stream.CopyTo(ms);
+                        ms.Position = 0;
+                        AddFileToTemplate(template, ms, folderWebRelativeUrl, fileName, folderWebRelativeUrl);
+                    }
+                }
+                catch (WebException exc)
+                {
+
+                    WriteWarning($"Can't add file from url {serverRelativeUrl} : {exc}");
+                }
+            }
+            else
+            {
+                if (!System.IO.Path.IsPathRooted(Source))
+                {
+                    Source = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Source);
                 }
 
-                template.Files.Add(new OfficeDevPnP.Core.Framework.Provisioning.Model.File
+                // Load the file and add it to the .PNP file
+                using (var fs = System.IO.File.OpenRead(Source))
                 {
-                    Src = source,
-                    Folder = Folder,
-                    Level = FileLevel,
-                    Overwrite = FileOverwrite,
-                });
+                    Folder = Folder.Replace("\\", "/");
 
-                // Determine the output file name and path
-                var outFileName = System.IO.Path.GetFileName(Path);
-                var outPath = new FileInfo(Path).DirectoryName;
-
-                var fileSystemConnector = new FileSystemConnector(outPath, "");
-                var formatter = XMLPnPSchemaFormatter.LatestFormatter;
-                var extension = new FileInfo(Path).Extension.ToLowerInvariant();
-                if (extension == ".pnp")
-                {
-                    var provider = new XMLOpenXMLTemplateProvider(template.Connector as OpenXMLConnector);
-                    var templateFileName = outFileName.Substring(0, outFileName.LastIndexOf(".", StringComparison.Ordinal)) + ".xml";
-
-                    provider.SaveAs(template, templateFileName, formatter, TemplateProviderExtensions);
+                    var fileName = Source.IndexOf("\\") > 0 ? Source.Substring(Source.LastIndexOf("\\") + 1) : Source;
+                    var container = !string.IsNullOrEmpty(Container) ? Container : string.Empty;
+                    AddFileToTemplate(template, fs, Folder, fileName, container);
                 }
-                else
-                {
-                        XMLTemplateProvider provider = new XMLFileSystemTemplateProvider(Path, "");
-                        provider.SaveAs(template, Path, formatter, TemplateProviderExtensions);
-                }
+            }
+        }
+
+        private void AddFileToTemplate(ProvisioningTemplate template, Stream fs, string folder, string fileName, string container)
+        {
+            var source = !string.IsNullOrEmpty(container) ? (container + "/" + fileName) : fileName;
+
+            template.Connector.SaveFileStream(fileName, container, fs);
+
+            if (template.Connector is ICommitableFileConnector)
+            {
+                ((ICommitableFileConnector)template.Connector).Commit();
+            }
+
+            template.Files.Add(new OfficeDevPnP.Core.Framework.Provisioning.Model.File
+            {
+                Src = source,
+                Folder = folder,
+                Level = FileLevel,
+                Overwrite = FileOverwrite,
+            });
+
+            // Determine the output file name and path
+            var outFileName = System.IO.Path.GetFileName(Path);
+            var outPath = new FileInfo(Path).DirectoryName;
+
+            var fileSystemConnector = new FileSystemConnector(outPath, "");
+            var formatter = XMLPnPSchemaFormatter.LatestFormatter;
+            var extension = new FileInfo(Path).Extension.ToLowerInvariant();
+            if (extension == ".pnp")
+            {
+                var provider = new XMLOpenXMLTemplateProvider(template.Connector as OpenXMLConnector);
+                var templateFileName = outFileName.Substring(0, outFileName.LastIndexOf(".", StringComparison.Ordinal)) + ".xml";
+
+                provider.SaveAs(template, templateFileName, formatter, TemplateProviderExtensions);
+            }
+            else
+            {
+                XMLTemplateProvider provider = new XMLFileSystemTemplateProvider(Path, "");
+                provider.SaveAs(template, Path, formatter, TemplateProviderExtensions);
             }
         }
     }

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -551,6 +551,7 @@
     <Compile Include="ClientSidePages\SetClientSidePage.cs" />
     <Compile Include="ClientSidePages\AddClientSideText.cs" />
     <Compile Include="SiteDesigns\SetSiteScript.cs" />
+    <Compile Include="Utilities\StringExtensions.cs" />
     <Compile Include="WebParts\AddClientSideWebPart.cs" />
     <Compile Include="ClientSidePages\GetAvailableClientSideComponents.cs" />
     <Compile Include="ClientSidePages\RemoveClientSidePage.cs" />

--- a/Commands/Utilities/StringExtensions.cs
+++ b/Commands/Utilities/StringExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+namespace SharePointPnP.PowerShell.Commands.Utilities
+{
+    public static class StringExtensions
+    {
+        public static string ReplaceCaseInsensitive(this string input, string search, string replacement)
+        {
+            return Regex.Replace(
+                input,
+                Regex.Escape(search),
+                replacement.Replace("$", "$$"),
+                RegexOptions.IgnoreCase
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##

## What is in this Pull Request ? ##
This PR includes an update to the `Add-PnPFileToProvisioningTemplate` command. 
The commands now accepts a `SourceUrl` parameter that can add a file to a template directly taken in the currently connected Web.

Ex:

    Add-PnPFileToProvisioningTemplate -SourceUrl http://server/sites/coll/Shared%20Documents/sample-report.xlsx -Path C:\pnp\package.pnp