### PR TITLE
Added optional parameter LoginProviderName

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -188,6 +188,9 @@ PS:> Connect-PnPOnline -Url https://yourserver -ClientId <id> -HighTrustCertific
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_MAIN, HelpMessage = "If you want to connect to your on-premises SharePoint farm using ADFS")]
         public SwitchParameter UseAdfs;
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_MAIN, HelpMessage = "The name of the ADFS trusted login provider")]
+        public string LoginProviderName;
+
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_MAIN, HelpMessage = "Specifies a minimal server healthscore before any requests are executed.")]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_TOKEN, HelpMessage = "Specifies a minimal server healthscore before any requests are executed.")]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_WEBLOGIN, HelpMessage = "Specifies a minimal server healthscore before any requests are executed.")]
@@ -497,7 +500,7 @@ Use -PnPO365ManagementShell instead");
                     }
                 }
 #if !NETSTANDARD2_0
-                connection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), creds, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck);
+                connection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), creds, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, SkipTenantAdminCheck, LoginProviderName);
 #else
                 throw new NotImplementedException();
 #endif

--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -538,7 +538,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
         }
 
 #if !NETSTANDARD2_0
-        internal static SPOnlineConnection InstantiateAdfsConnection(Uri url, PSCredential credentials, PSHost host, int minimalHealthScore, int retryCount, int retryWait, int requestTimeout, string tenantAdminUrl, bool skipAdminCheck = false)
+        internal static SPOnlineConnection InstantiateAdfsConnection(Uri url, PSCredential credentials, PSHost host, int minimalHealthScore, int retryCount, int retryWait, int requestTimeout, string tenantAdminUrl, bool skipAdminCheck = false, string loginProviderName = null)
         {
             var authManager = new OfficeDevPnP.Core.AuthenticationManager();
 
@@ -546,7 +546,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
 
             string adfsHost;
             string adfsRelyingParty;
-            GetAdfsConfigurationFromTargetUri(url, out adfsHost, out adfsRelyingParty);
+            GetAdfsConfigurationFromTargetUri(url, loginProviderName, out adfsHost, out adfsRelyingParty);
 
             if (string.IsNullOrEmpty(adfsHost) || string.IsNullOrEmpty(adfsRelyingParty))
             {
@@ -629,12 +629,12 @@ namespace SharePointPnP.PowerShell.Commands.Base
             return null;
         }
 
-        public static void GetAdfsConfigurationFromTargetUri(Uri targetApplicationUri, out string adfsHost, out string adfsRelyingParty)
+        public static void GetAdfsConfigurationFromTargetUri(Uri targetApplicationUri, string loginProviderName, out string adfsHost, out string adfsRelyingParty)
         {
             adfsHost = "";
             adfsRelyingParty = "";
 
-            var trustEndpoint = new Uri(new Uri(targetApplicationUri.GetLeftPart(UriPartial.Authority)), "/_trust/");
+            var trustEndpoint = new Uri(new Uri(targetApplicationUri.GetLeftPart(UriPartial.Authority)), !string.IsNullOrWhiteSpace(loginProviderName) ? $"/_trust/?trust={loginProviderName}" : "/_trust/");
             var request = (HttpWebRequest)WebRequest.Create(trustEndpoint);
             request.AllowAutoRedirect = false;
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
SharePoint on-premise supports multiple identity providers. The page /_trust/default.aspx evaluates a request parameter named "trust" to identify the TrustedLoginProvider by name (Microsoft.SharePoint.IdentityModel.Pages.TrustedProviderSignInPage, member: LoginProvider)
This PR adds a new parameter named "LoginProviderName" to the Connect-SPOnline command and passes it as querystring while determining the wsfed parameters while creating a Adfs based client-context.

If the parameter is ommited, the old behaviour applies.