### PR TITLE
Exclude O365 only commands from on premises compilation

### DIFF
--- a/Commands/UserProfiles/GetUPABulkImportStatus.cs
+++ b/Commands/UserProfiles/GetUPABulkImportStatus.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !ONPREMISES
+using System;
 using System.Management.Automation;
 using Microsoft.Online.SharePoint.TenantManagement;
 using Microsoft.SharePoint.Client;
@@ -84,3 +85,4 @@ namespace SharePointPnP.PowerShell.Commands.UserProfiles
         }
     }
 }
+#endif

--- a/Commands/UserProfiles/NewUPABulkImportJob.cs
+++ b/Commands/UserProfiles/NewUPABulkImportJob.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !ONPREMISES
+using System;
 using System.Collections;
 using System.ComponentModel;
 using System.Linq;
@@ -92,3 +93,4 @@ PS:> New-PnPUPABulkImportJob -Folder ""Shared Documents"" -Path profiles.json -I
         }
     }
 }
+#endif


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
This PR contains a small fix that excludes O365 only commands to be compiled when configuration is 15 or 16.