### PR TITLE
Allow -FileName with Add-PnPFile -Path

### DIFF
--- a/Commands/Files/AddFile.cs
+++ b/Commands/Files/AddFile.cs
@@ -6,9 +6,6 @@ using OfficeDevPnP.Core.Utilities;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 using System;
-using System.Linq;
-using System.Collections.Generic;
-using Microsoft.SharePoint.Client.Taxonomy;
 using SharePointPnP.PowerShell.Commands.Utilities;
 using SharePointPnP.PowerShell.Commands.Enums;
 
@@ -43,6 +40,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
         Code = @"PS:> Add-PnPFile -FileName sample.docx -Folder ""Documents"" -Values @{Modified=""1/1/2016""; Created=""1/1/2017""; Editor=23}",
         Remarks = "This will add a file sample.docx to the Documents folder and will set the Modified date to 1/1/2016, Created date to 1/1/2017 and the Modified By field to the user with ID 23. To find out about the proper user ID to relate to a specific user, use Get-PnPUser.",
         SortOrder = 6)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPFile -FileName sample.docx -Folder ""Documents"" -FileName ""differentname.docx""",
+        Remarks = "This will upload a local file sample.docx to the Documents folder giving it the filename differentname.docx on SharePoint",
+        SortOrder = 7)]
 
     public class AddFile : PnPWebCmdlet
     {
@@ -56,10 +57,10 @@ namespace SharePointPnP.PowerShell.Commands.Files
         public string Folder = string.Empty;
 
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ASSTREAM, HelpMessage = "Name for file")]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ASFILE, HelpMessage = "Filename to give the file on SharePoint")]
         public string FileName = string.Empty;
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ASSTREAM, HelpMessage = "Stream with the file contents")]
         public Stream Stream;
-
 
         [Parameter(Mandatory = false, HelpMessage = "If versioning is enabled, this will check out the file first if it exists, upload the file, then check it in again.")]
         public SwitchParameter Checkout;
@@ -109,14 +110,16 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
-
             if (ParameterSetName == ParameterSet_ASFILE)
             {
                 if (!System.IO.Path.IsPathRooted(Path))
                 {
                     Path = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Path);
                 }
-                FileName = System.IO.Path.GetFileName(Path);
+                if (string.IsNullOrEmpty(FileName))
+                {
+                    FileName = System.IO.Path.GetFileName(Path);
+                }
             }
 
             SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
@@ -128,7 +131,6 @@ namespace SharePointPnP.PowerShell.Commands.Files
             //Check to see if the Content Type exists.. If it doesn't we are going to throw an exception and block this transaction right here.
             if (ContentType != null)
             {
-
                 try
                 {
                     var list = SelectedWeb.GetListByUrl(folder.ServerRelativeUrl);

--- a/Commands/Files/AddFile.cs
+++ b/Commands/Files/AddFile.cs
@@ -41,7 +41,7 @@ namespace SharePointPnP.PowerShell.Commands.Files
         Remarks = "This will add a file sample.docx to the Documents folder and will set the Modified date to 1/1/2016, Created date to 1/1/2017 and the Modified By field to the user with ID 23. To find out about the proper user ID to relate to a specific user, use Get-PnPUser.",
         SortOrder = 6)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPFile -FileName sample.docx -Folder ""Documents"" -FileName ""differentname.docx""",
+        Code = @"PS:> Add-PnPFile -FileName sample.docx -Folder ""Documents"" -NewFileName ""differentname.docx""",
         Remarks = "This will upload a local file sample.docx to the Documents folder giving it the filename differentname.docx on SharePoint",
         SortOrder = 7)]
 
@@ -57,8 +57,11 @@ namespace SharePointPnP.PowerShell.Commands.Files
         public string Folder = string.Empty;
 
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ASSTREAM, HelpMessage = "Name for file")]
-        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ASFILE, HelpMessage = "Filename to give the file on SharePoint")]
         public string FileName = string.Empty;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ASFILE, HelpMessage = "Filename to give the file on SharePoint")]
+        public string NewFileName = string.Empty;
+
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ASSTREAM, HelpMessage = "Stream with the file contents")]
         public Stream Stream;
 
@@ -116,9 +119,13 @@ namespace SharePointPnP.PowerShell.Commands.Files
                 {
                     Path = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Path);
                 }
-                if (string.IsNullOrEmpty(FileName))
+                if (string.IsNullOrEmpty(NewFileName))
                 {
                     FileName = System.IO.Path.GetFileName(Path);
+                }
+                else
+                {
+                    FileName = NewFileName;
                 }
             }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added the ability to optionally specify a filename to assign to a file when uploading it. Currently the filename in SharePoint needs to match the filename it has on your local machine from where you are uploading it with Add-PnPFile. I've often been in situations with customers where you want to give it a different name in SharePoint than it has on your local machine. I.e. when uploading large amounts of the same document for creating a load test set. By allowing -FileName to be used now you have a one line Add-PnPFile -Path C:\somefile.txt -FileName differentname.txt -Folder "Shared Documents" option now to achieve this in 1 step.