### PR TITLE
Add get content type from list with doc set

### DIFF
--- a/Commands/DocumentSets/AddDocumentSet.cs
+++ b/Commands/DocumentSets/AddDocumentSet.cs
@@ -3,13 +3,14 @@ using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.DocumentSet;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using System.Linq;
 
 namespace SharePointPnP.PowerShell.Commands.DocumentSets
 {
     [Cmdlet(VerbsCommon.Add, "PnPDocumentSet")]
     [CmdletHelp("Creates a new document set in a library.",
       Category = CmdletHelpCategory.DocumentSets,
-        OutputType=typeof(string))]
+        OutputType = typeof(string))]
     [CmdletExample(
       Code = @"PS:> Add-PnPDocumentSet -List ""Documents"" -ContentType ""Test Document Set"" -Name ""Test""",
       Remarks = "This will add a new document set based upon the 'Test Document Set' content type to a list called 'Documents'. The document set will be named 'Test'",
@@ -19,18 +20,41 @@ namespace SharePointPnP.PowerShell.Commands.DocumentSets
         [Parameter(Mandatory = true, HelpMessage = "The name of the list, its ID or an actual list object from where the document set needs to be added")]
         public ListPipeBind List;
 
-        [Parameter(Mandatory = true, HelpMessage = "The name of the document set")] 
+        [Parameter(Mandatory = true, HelpMessage = "The name of the document set")]
         public string Name;
 
-        [Parameter(Mandatory = true, HelpMessage = "The name of the content type, its ID or an actual content object referencing to the document set.")] 
+        [Parameter(Mandatory = true, HelpMessage = "The name of the content type, its ID or an actual content object referencing to the document set")]
         public ContentTypePipeBind ContentType;
+
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
-            list.EnsureProperty(l => l.RootFolder);
+            list.EnsureProperties(l => l.RootFolder, l => l.ContentTypes);
 
-            var result = DocumentSet.Create(ClientContext, list.RootFolder, Name, ContentType.GetContentType(SelectedWeb).Id);
+            // Try getting the content type from the Web
+            var contentType = ContentType.GetContentType(SelectedWeb);
 
+            // If content type could not be found but a content type ID has been passed in, try looking for the content type ID on the list instead
+            if (contentType == null && !string.IsNullOrEmpty(ContentType.Id))
+            {
+                contentType = list.ContentTypes.FirstOrDefault(ct => ct.StringId.Equals(ContentType.Id));
+            }
+            else
+            {
+                // Content type has been found on the web, check if it also exists on the list
+                if (list.ContentTypes.All(ct => !ct.StringId.Equals(contentType.Id.StringValue, System.StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    contentType = list.ContentTypes.FirstOrDefault(ct => ct.Name.Equals(ContentType.Name));
+                }
+            }
+
+            if (contentType == null)
+            {
+                throw new PSArgumentException("The provided contenttype has not been found", "ContentType");
+            }
+
+            // Create the document set
+            var result = DocumentSet.Create(ClientContext, list.RootFolder, Name, contentType.Id);
             ClientContext.ExecuteQueryRetry();
 
             WriteObject(result.Value);


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
https://github.com/SharePoint/PnP-PowerShell/issues/644

## What is in this Pull Request ? ##
As described in https://github.com/SharePoint/PnP-PowerShell/issues/644 when trying to create a new Document Set using:

Add-PnpDocumentSet -Name "Test1" -List "Shared Documents" -ContentType "Documentset"

It does create a folder in the document library, but it doesn't apply the document set content type to it. This is because the content type is currently being retrieved from the web. While assigning the default  Document Set content type to a document library however, it automatically creates an inheritance of it with it's own ID. Trying to create the document set with the document set ID of the web won't work in this case as it doesn't exist on the list. The code adjustment I checked in ensures that now any of these usages of the Add-PnPDocumentSet will work:

Add-PnpDocumentSet -Name "Test1" -List "Shared Documents" -ContentType "Documentset"

$ct = Get-PnPContentType -List "Shared Documents" -Identity "Document Set"
Add-PnpDocumentSet -Name "Test1" -List "Shared Documents" -ContentType $ct

$ct = Get-PnPContentType -List "Shared Documents" -Identity "Document Set"
Add-PnpDocumentSet -Name "Test1" -List "Shared Documents" -ContentType $ct.Id.StringValue
