### PR TITLE
Added compliancetag support, this enables to set Labels to specified …

### DIFF
--- a/Commands/InformationManagement/GetLabel.cs
+++ b/Commands/InformationManagement/GetLabel.cs
@@ -1,0 +1,46 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.InformationManagement
+{
+    [Cmdlet(VerbsCommon.Get, "PnPLabel")]
+    [CmdletHelp("Gets the label/tag of the specfied list or library (if applicable)", Category = CmdletHelpCategory.InformationManagement)]
+    [CmdletExample(
+       Code = @"PS:> Get-PnPLabel -List ""Demo List""",
+       Remarks = @"This gets the label which is set to a list or a library.", SortOrder = 1)]
+
+    public class GetListComplianceTag : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID or Url of the list.")]
+        public ListPipeBind List;
+
+        protected override void ExecuteCmdlet()
+        {
+            var list = List.GetList(SelectedWeb);
+            if (list != null)
+            {
+                var listUrl = list.RootFolder.ServerRelativeUrl;
+                var label = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetListComplianceTag(ClientContext, listUrl);
+                ClientContext.ExecuteQueryRetry();
+
+                if (label.Value == null)
+                {
+                    WriteWarning("No label found for the specified library.");
+                }
+                else
+                {
+                    WriteObject("The label '" + label.Value.TagName + "' is set to the specified list or library. ");
+                    // There is no property yet that exposes if the SyncToItems is set or not.. :(
+                    WriteObject("Block deletion: " + label.Value.BlockDelete.ToString());
+                    WriteObject("Block editing: " + label.Value.BlockEdit.ToString());
+                }
+            }
+            else
+            {
+                WriteWarning("List or library not found.");
+            }
+        }
+    }
+}

--- a/Commands/InformationManagement/SetLabel.cs
+++ b/Commands/InformationManagement/SetLabel.cs
@@ -1,0 +1,62 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.InformationManagement
+{
+    [Cmdlet(VerbsCommon.Set, "PnPLabel")]
+    [CmdletHelp("Sets a label/tag on the specified list or library", Category = CmdletHelpCategory.InformationManagement)]
+    [CmdletExample(
+       Code = @"PS:> Set-PnPLabel  -List ""Demo List"" -Label ""Project Documentation""",
+       Remarks = @"This sets an O365 label on the specified list or library. ", SortOrder = 1)]
+    [CmdletExample(
+       Code = @"PS:> Set-PnPLabel  -List ""Demo List"" -Label ""Project Documentation"" -SyncToItems $true",
+       Remarks = @"This sets an O365 label on the specified list or library and sets the label to all the items in the list and library as well.", SortOrder = 2)]
+
+    [CmdletExample(
+       Code = @"PS:> Set-PnPLabel  -List ""Demo List"" -Label ""Project Documentation"" -BlockDelete $true -BlockEdit $true",
+       Remarks = @"This sets an O365 label on the specified list or library. Next, it also blocks the ability to either edit or delete the item. ", SortOrder = 3)]
+    public class SetListComplianceTag : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID or Url of the list.")]
+        public ListPipeBind List;
+
+        [Parameter(Mandatory = true, HelpMessage = "The name of the label.")]
+        public string Label;
+
+        [Parameter(Mandatory = false, HelpMessage = "Apply label to existing items in the library.")]
+        public bool SyncToItems;
+
+        [Parameter(Mandatory = false, HelpMessage = "Block deletion of items in the library.")]
+        public bool BlockDeletion;
+
+        [Parameter(Mandatory = false, HelpMessage = "Block edititing of items in the library.")]
+        public bool BlockEdit;
+
+        protected override void ExecuteCmdlet()
+        {
+            var list = List.GetList(SelectedWeb);
+            if (list != null)
+            {
+                var listUrl = list.RootFolder.ServerRelativeUrl;
+                Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.SetListComplianceTag(ClientContext, listUrl, Label, SyncToItems, BlockEdit, BlockDeletion);
+
+                try
+                {
+                    ClientContext.ExecuteQueryRetry();
+                }
+                catch (System.Exception error)
+                {
+                    WriteWarning(error.Message.ToString());
+                }
+
+            }
+            else
+            {
+                WriteWarning("List or library not found.");
+
+            }
+        }
+    }
+}

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -467,6 +467,8 @@
     <Compile Include="Base\PipeBinds\TenantSiteDesignPipeBind.cs" />
     <Compile Include="Enums\ListItemUpdateType.cs" />
     <Compile Include="Enums\StorageEntityScope.cs" />
+    <Compile Include="InformationManagement\GetLabel.cs" />
+    <Compile Include="InformationManagement\SetLabel.cs" />
     <Compile Include="Model\ServicePrincipalPermissionGrant.cs" />
     <Compile Include="Navigation\GetNavigationNode.cs" />
     <Compile Include="Branding\SetWebTheme.cs" />


### PR DESCRIPTION
Added cmdlets to get/set labels (aka compliancetags) on specified lists and/or libraries. Since the CSOM March 2018 release there is support to get/set these, hence this PnP version to make life easier. 

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
In the InformationManagement namespace there are two new cmdlets added:
- GetLabel.cs
- SetLabel.cs
