### PR TITLE
Added default pipebind to Get-PnPListItem

### DIFF
--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -48,7 +48,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         private const string ParameterSet_BYUNIQUEID = "By Unique Id";
         private const string ParameterSet_BYQUERY = "By Query";
         private const string ParameterSet_ALLITEMS = "All Items";
-        [Parameter(Mandatory = true, HelpMessage = "The list to query", Position = 0, ParameterSetName = ParameterAttribute.AllParameterSets)]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The list to query", Position = 0, ParameterSetName = ParameterAttribute.AllParameterSets)]
         public ListPipeBind List;
 
         [Parameter(Mandatory = false, HelpMessage = "The ID of the item to retrieve", ParameterSetName = ParameterSet_BYID)]


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
I've marked the ListPipeBind as the default pipebind to align with Add-PnPListItem and Remove-PnPListItem where this was already the case. This would now allow a nice chaining of the following methods to retrieve list items from a list:

`
Get-PnPList -Identity "Tasks" | Get-PnPListItem
`

The same could be done already for Get-PnPList -Identity "Tasks" | Add-PnPListItem and Get-PnPList -Identity "Tasks" | Remove-PnPListItem but not for Get-PnPListItem which is weird and inconsistent.