### PR TITLE
GetUser - Updated group logic to only add users in groups with access rights

### DIFF
--- a/Commands/Principals/GetUser.cs
+++ b/Commands/Principals/GetUser.cs
@@ -12,7 +12,7 @@ namespace SharePointPnP.PowerShell.Commands.Principals
     [Cmdlet(VerbsCommon.Get, "PnPUser")]
     [CmdletHelp("Returns site users of current web",
         Category = CmdletHelpCategory.Principals,
-        DetailedDescription = "This command will return all the users that exist in the current site collection its User Information List",
+        DetailedDescription = "This command will return all users that exist in the current site collection's User Information List",
         OutputType = typeof(User),
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.user.aspx")]
     [CmdletExample(

--- a/Commands/Principals/GetUser.cs
+++ b/Commands/Principals/GetUser.cs
@@ -84,13 +84,13 @@ namespace SharePointPnP.PowerShell.Commands.Principals
                     var usersWithDirectPermissions = SelectedWeb.SiteUsers.Where(u => SelectedWeb.RoleAssignments.Any(ra => ra.Member.LoginName == u.LoginName));
 
                     // Get all the users contained in SharePoint Groups
-                    SelectedWeb.Context.Load(SelectedWeb.SiteGroups, sg => sg.Include(u => u.Users.Include(retrievalExpressions)));
+                    SelectedWeb.Context.Load(SelectedWeb.SiteGroups, sg => sg.Include(u => u.Users.Include(retrievalExpressions), u => u.LoginName));
                     SelectedWeb.Context.ExecuteQueryRetry();
 
+                    // Get all SharePoint groups that have been assigned access
                     var usersWithGroupPermissions = new List<User>();
-                    foreach (var group in SelectedWeb.SiteGroups)
+                    foreach (var group in SelectedWeb.SiteGroups.Where(g => SelectedWeb.RoleAssignments.Any(ra => ra.Member.LoginName == g.LoginName)))
                     {
-                        // If they're in a SharePoint Group, they always have some kind of access rights, so add them all
                         usersWithGroupPermissions.AddRange(group.Users);
                     }
 


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
When running Get-PnPUser against a subweb, to which not all groups were granted access, a wrong set of users was returned.
For example:
/sites/test: user1, user2, group1(user3,user4), group2(user5)
/sites/test/private: user1,group2(user5)

Previously, this returned user1, user3, user4, user5.
Now it correctly returns user1, user5