### PR TITLE
Get-PnPTenantRecycleBinItem to also include modern sites

### DIFF
--- a/Commands/RecycleBin/GetTenantRecycleBinItem.cs
+++ b/Commands/RecycleBin/GetTenantRecycleBinItem.cs
@@ -16,13 +16,20 @@ namespace SharePointPnP.PowerShell.Commands.RecycleBin
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.online.sharepoint.tenantadministration.deletedsiteproperties.aspx")]
     [CmdletExample(
         Code = @"PS:> Get-PnPTenantRecycleBinItem",
-        Remarks = "Returns all site collections in the tenant scoped recycle bin",
+        Remarks = "Returns all classic site collections in the tenant scoped recycle bin",
         SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPTenantRecycleBinItem -IncludeModernSites",
+        Remarks = "Returns all modern and classic site collections in the tenant scoped recycle bin",
+        SortOrder = 2)]
     public class GetTenantRecycleBinItems : PnPAdminCmdlet
     {
+        [Parameter(Mandatory = false, HelpMessage = "If provided, it will also return all Modern Sites next to the classic sites that have been deleted and are in the tenant scoped recycle bin")]
+        public SwitchParameter IncludeModernSites;
+
         protected override void ExecuteCmdlet()
         {
-            var deletedSites = Tenant.GetDeletedSiteProperties(0);
+            var deletedSites = IncludeModernSites ? Tenant.GetDeletedSitePropertiesFromSharePoint("0") : Tenant.GetDeletedSiteProperties(0);
             ClientContext.Load(deletedSites, c => c.IncludeWithDefaultProperties(s => s.Url, s => s.SiteId, s => s.DaysRemaining, s => s.Status));
             ClientContext.ExecuteQueryRetry();
             if (deletedSites.AreItemsAvailable)

--- a/Commands/RecycleBin/GetTenantRecycleBinItem.cs
+++ b/Commands/RecycleBin/GetTenantRecycleBinItem.cs
@@ -8,7 +8,7 @@ using SharePointPnP.PowerShell.Commands.Base;
 namespace SharePointPnP.PowerShell.Commands.RecycleBin
 {
     [Cmdlet(VerbsCommon.Get, "PnPTenantRecycleBinItem", DefaultParameterSetName = "All")]
-    [CmdletHelp("Returns the items in the tenant scoped recycle bin",
+    [CmdletHelp("Returns all modern and classic site collections in the tenant scoped recycle bin",
         DetailedDescription = "This command will return all the items in the tenant recycle bin for the Office 365 tenant you are connected to. Be sure to connect to the SharePoint Online Admin endpoint (https://yourtenantname-admin.sharepoint.com) in order for this command to work.",
         Category = CmdletHelpCategory.RecycleBin,
         SupportedPlatform = CmdletSupportedPlatform.Online,
@@ -16,20 +16,13 @@ namespace SharePointPnP.PowerShell.Commands.RecycleBin
         OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.online.sharepoint.tenantadministration.deletedsiteproperties.aspx")]
     [CmdletExample(
         Code = @"PS:> Get-PnPTenantRecycleBinItem",
-        Remarks = "Returns all classic site collections in the tenant scoped recycle bin",
-        SortOrder = 1)]
-    [CmdletExample(
-        Code = @"PS:> Get-PnPTenantRecycleBinItem -IncludeModernSites",
         Remarks = "Returns all modern and classic site collections in the tenant scoped recycle bin",
-        SortOrder = 2)]
+        SortOrder = 1)]
     public class GetTenantRecycleBinItems : PnPAdminCmdlet
     {
-        [Parameter(Mandatory = false, HelpMessage = "If provided, it will also return all Modern Sites next to the classic sites that have been deleted and are in the tenant scoped recycle bin")]
-        public SwitchParameter IncludeModernSites;
-
         protected override void ExecuteCmdlet()
         {
-            var deletedSites = IncludeModernSites ? Tenant.GetDeletedSitePropertiesFromSharePoint("0") : Tenant.GetDeletedSiteProperties(0);
+            var deletedSites = Tenant.GetDeletedSitePropertiesFromSharePoint("0");
             ClientContext.Load(deletedSites, c => c.IncludeWithDefaultProperties(s => s.Url, s => s.SiteId, s => s.DaysRemaining, s => s.Status));
             ClientContext.ExecuteQueryRetry();
             if (deletedSites.AreItemsAvailable)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added -IncludeModernSites switch to Get-PnPTenantRecycleBinItem to also include modern sites in the tenant scoped recycle bin. Without it, it will only return classic sites being in the tenant scoped recycle bin