### PR TITLE
Updated Readme to mention UseWebLogin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ To use the library you first need to connect to your tenant:
 Connect-PnPOnline –Url https://yoursite.sharepoint.com –Credentials (Get-Credential)
 ```
 
+Or if you have Multi Factor Authentication enabled or if you are using a federated identity provider like AD FS, instead use:
+
+```powershell
+Connect-PnPOnline –Url https://yoursite.sharepoint.com –UseWebLogin
+```
+
 To view all cmdlets, enter:
 
 ```powershell


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [X] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
As most SPO tenants these days will use at least MFA, I believe it would be good to show the proper way to connect using PnP PowerShell, being using -UseWebLogin. I've added this in the readme. I had some students in my class this week that were confused by this default option proposed here to connect.
