### PR TITLE
Changed Enable\Disable telemetry to work without a connection

### DIFF
--- a/Commands/Base/DisablePowerShellTelemetry.cs
+++ b/Commands/Base/DisablePowerShellTelemetry.cs
@@ -1,15 +1,11 @@
 ﻿using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using System;
-using System.Collections.Generic;
 #if NETSTANDARD2_0
 using System.IdentityModel.Tokens.Jwt;
 #else
 using System.IdentityModel.Tokens;
 #endif
-using System.Linq;
 using System.Management.Automation;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SharePointPnP.PowerShell.Commands.Base
 {
@@ -21,6 +17,10 @@ namespace SharePointPnP.PowerShell.Commands.Base
        Code = "PS:> Disable-PnPPowerShellTelemetry",
        Remarks = "Will prompt you to confirm to disable telemetry tracking.",
        SortOrder = 1)]
+    [CmdletExample(
+       Code = "PS:> Disable-PnPPowerShellTelemetry -Force",
+       Remarks = "Will disable telemetry tracking without prompting.",
+       SortOrder = 2)]
     public class DisablePowerShellTelemetry : PSCmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
@@ -33,7 +33,10 @@ namespace SharePointPnP.PowerShell.Commands.Base
             if (Force || ShouldContinue("Do you want to disable telemetry for PnP PowerShell?", "Confirm"))
             {
                 System.IO.File.WriteAllText(telemetryFile, "disallow");
-                SPOnlineConnection.CurrentConnection.TelemetryClient = null;
+                if (SPOnlineConnection.CurrentConnection != null)
+                {
+                    SPOnlineConnection.CurrentConnection.TelemetryClient = null;
+                }
                 WriteObject("Telemetry disabled");
             }
             else

--- a/Commands/Base/EnablePowerShellTelemetry.cs
+++ b/Commands/Base/EnablePowerShellTelemetry.cs
@@ -12,6 +12,10 @@ namespace SharePointPnP.PowerShell.Commands.Base
        Code = "PS:> Enable-PnPPowerShellTelemetry",
        Remarks = "Will prompt you to confirm to enable telemetry tracking.",
        SortOrder = 1)]
+    [CmdletExample(
+       Code = "PS:> Enable-PnPPowerShellTelemetry",
+       Remarks = "Will enable telemetry tracking without prompting.",
+       SortOrder = 2)]
     public class EnablePowerShellTelemetry : PSCmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
@@ -23,7 +27,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
             var telemetryFile = System.IO.Path.Combine(userFolder, ".pnppowershelltelemetry");
             if (Force || ShouldContinue("Do you want to enable telemetry for PnP PowerShell?", "Confirm"))
             {
-                SPOnlineConnection.CurrentConnection.InitializeTelemetry(SPOnlineConnection.CurrentConnection.Context, Host);
+                SPOnlineConnection.CurrentConnection?.InitializeTelemetry(SPOnlineConnection.CurrentConnection.Context, Host);
                 System.IO.File.WriteAllText(telemetryFile, "allow");
                 WriteObject("Telemetry enabled");
             }

--- a/Commands/Base/EnablePowerShellTelemetry.cs
+++ b/Commands/Base/EnablePowerShellTelemetry.cs
@@ -13,7 +13,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
        Remarks = "Will prompt you to confirm to enable telemetry tracking.",
        SortOrder = 1)]
     [CmdletExample(
-       Code = "PS:> Enable-PnPPowerShellTelemetry",
+       Code = "PS:> Enable-PnPPowerShellTelemetry -Force",
        Remarks = "Will enable telemetry tracking without prompting.",
        SortOrder = 2)]
     public class EnablePowerShellTelemetry : PSCmdlet


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
When enabling or disabling  telemetry using Enable-PnPPowerShellTelemetry and Disable-PnPPowerShellTelemetry without having set up a connection first, it would throw a nullreference exception. As far as I can judge from the code, the most important thing is for it to write allow or disallow to the .pnppowershelltelemetry file in the user profile root folder, so this will work perfectly fine without an active connection as well. Changing this code helps in automatically setting up environments and installing PnP PowerShell and disabling telemetry on them before having an environment available to connect to. Also added a sample for using Force and removed unused usings.
