### PR TITLE
Fix: Additional null check while processing storage entities

### DIFF
--- a/Commands/Admin/GetStorageEntity.cs
+++ b/Commands/Admin/GetStorageEntity.cs
@@ -34,10 +34,17 @@ namespace SharePointPnP.PowerShell.Commands
             if (Scope == StorageEntityScope.Tenant)
             {
                 var appCatalogUri = ClientContext.Web.GetAppCatalog();
-                using (var clonedContext = ClientContext.Clone(appCatalogUri))
+                if(appCatalogUri != null)
                 {
-                    storageEntitiesIndex = clonedContext.Web.GetPropertyBagValueString("storageentitiesindex", "");
+                    using (var clonedContext = ClientContext.Clone(appCatalogUri))
+                    {
+                        storageEntitiesIndex = clonedContext.Web.GetPropertyBagValueString("storageentitiesindex", "");
+                    }
                 }
+                else
+                {
+                    WriteWarning("Tenant app catalog is not available on this tenant.");
+                }                
             }
             else
             {

--- a/Commands/Admin/RemoveStorageEntity.cs
+++ b/Commands/Admin/RemoveStorageEntity.cs
@@ -31,12 +31,20 @@ namespace SharePointPnP.PowerShell.Commands
             if (Scope == StorageEntityScope.Tenant)
             {
                 var appCatalogUri = ClientContext.Web.GetAppCatalog();
-                using (var clonedContext = ClientContext.Clone(appCatalogUri))
+                if(appCatalogUri != null)
                 {
-                    clonedContext.Web.RemoveStorageEntity(Key);
-                    clonedContext.ExecuteQueryRetry();
+                    using (var clonedContext = ClientContext.Clone(appCatalogUri))
+                    {
+                        clonedContext.Web.RemoveStorageEntity(Key);
+                        clonedContext.ExecuteQueryRetry();
+                    }
                 }
-            } else
+                else
+                {
+                    WriteWarning("Tenant app catalog is not available on this tenant.");
+                }                
+            }
+            else
             {
                 var appcatalog = ClientContext.Site.RootWeb.SiteCollectionAppCatalog;
                 ClientContext.Load(appcatalog);

--- a/Commands/Admin/SetStorageEntity.cs
+++ b/Commands/Admin/SetStorageEntity.cs
@@ -42,10 +42,17 @@ namespace SharePointPnP.PowerShell.Commands
             if (Scope == StorageEntityScope.Tenant)
             {
                 var appCatalogUri = ClientContext.Web.GetAppCatalog();
-                using (var clonedContext = ClientContext.Clone(appCatalogUri))
+                if(appCatalogUri != null)
                 {
-                    clonedContext.Web.SetStorageEntity(Key, Value, Description, Comment);
-                    clonedContext.ExecuteQueryRetry();
+                    using (var clonedContext = ClientContext.Clone(appCatalogUri))
+                    {
+                        clonedContext.Web.SetStorageEntity(Key, Value, Description, Comment);
+                        clonedContext.ExecuteQueryRetry();
+                    }
+                }
+                else
+                {
+                    WriteWarning("Tenant app catalog is not available on this tenant.");
                 }
             }
             else


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##

This PR does an additional null check for the storage entities commandlets.
When you run execute them on brand new tenants which don't have tenant app catalog configured, PnP PowerShell throws `Object reference not set` error.