### PR TITLE
Connect-PnpOnline: Kerberos authentication using ADFS

### DIFF
--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -556,7 +556,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
 
             string adfsHost;
             string adfsRelyingParty;
-            GetAdfsConfigurationFromTargetUri(url, loginProviderName, out adfsHost, out adfsRelyingParty);
+            OfficeDevPnP.Core.AuthenticationManager.GetAdfsConfigurationFromTargetUri(url, loginProviderName, out adfsHost, out adfsRelyingParty);
 
             if (string.IsNullOrEmpty(adfsHost) || string.IsNullOrEmpty(adfsRelyingParty))
             {
@@ -661,35 +661,6 @@ namespace SharePointPnP.PowerShell.Commands.Base
                 }
             }
             return null;
-        }
-
-        public static void GetAdfsConfigurationFromTargetUri(Uri targetApplicationUri, string loginProviderName, out string adfsHost, out string adfsRelyingParty)
-        {
-            adfsHost = "";
-            adfsRelyingParty = "";
-
-            var trustEndpoint = new Uri(new Uri(targetApplicationUri.GetLeftPart(UriPartial.Authority)), !string.IsNullOrWhiteSpace(loginProviderName) ? $"/_trust/?trust={loginProviderName}" : "/_trust/");
-            var request = (HttpWebRequest)WebRequest.Create(trustEndpoint);
-            request.AllowAutoRedirect = false;
-
-            try
-            {
-                using (var response = request.GetResponse())
-                {
-                    var locationHeader = response.Headers["Location"];
-                    if (locationHeader != null)
-                    {
-                        var redirectUri = new Uri(locationHeader);
-                        Dictionary<string, string> queryParameters = Regex.Matches(redirectUri.Query, "([^?=&]+)(=([^&]*))?").Cast<Match>().ToDictionary(x => x.Groups[1].Value, x => Uri.UnescapeDataString(x.Groups[3].Value));
-                        adfsHost = redirectUri.Host;
-                        adfsRelyingParty = queryParameters["wtrealm"];
-                    }
-                }
-            }
-            catch (WebException ex)
-            {
-                throw new Exception("Endpoint does not use ADFS for authentication.", ex);
-            }
         }
 
         private static bool IsTenantAdminSite(ClientRuntimeContext clientContext)


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##

None

## Related Pullrequest ##

https://github.com/SharePoint/PnP-Sites-Core/pull/2050

## What is in this Pull Request ? ##

This pull request contains an enhancement with which the authentication to a SharePoint server using an ADFS instance is possible by using kerberos authentication. Currently authenticating via ADFS is only possible with login/password and using a X.509 certificate. For a justification refer to [PR #2050 in PnP-Sites-Core](https://github.com/SharePoint/PnP-Sites-Core/pull/2050).

**Sample**
```Powershell
$ Connect-PnpOnline -Url https://sharepoint.onpremisses.local -Kerberos -UseAdfs
```
Secondly the method `GetAdfsConfigurationFromTargetUri` from `SPOnlineConnectionHelper.cs` has been moved to the AuthenticationManager class in the Core Framework for public usage.



