### PR TITLE
Added ValueFromPipeline to Remove-PnPUnifiedGroup

### DIFF
--- a/Commands/Graph/RemoveUnifiedGroup.cs
+++ b/Commands/Graph/RemoveUnifiedGroup.cs
@@ -1,33 +1,31 @@
 ﻿using OfficeDevPnP.Core.Entities;
 using OfficeDevPnP.Core.Framework.Graph;
-using OfficeDevPnP.Core.Utilities;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Remove, "PnPUnifiedGroup")]
-    [CmdletHelp("Removes one Office 365 Group (aka Unified Group) or a list of Office 365 Groups",
+    [CmdletHelp("Removes one Office 365 Group (aka Unified Group)",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(
        Code = "PS:> Remove-PnPUnifiedGroup -Identity $groupId",
-       Remarks = "Removes an Office 365 Groups based on its ID",
+       Remarks = "Removes an Office 365 Group based on its ID",
        SortOrder = 1)]
     [CmdletExample(
        Code = "PS:> Remove-PnPUnifiedGroup -Identity $group",
-       Remarks = "Removes the provided Office 365 Groups",
+       Remarks = "Removes the provided Office 365 Group",
        SortOrder = 2)]
+    [CmdletExample(
+       Code = "PS:> Get-PnPUnifiedGroup | ? Visibility -eq \"Public\" | Remove-PnPUnifiedGroup",
+       Remarks = "Removes all the public Office 365 Groups",
+       SortOrder = 3)]
     public class RemoveUnifiedGroup : PnPGraphCmdlet
     {
-        [Parameter(Mandatory = true, HelpMessage = "The Identity of the Office 365 Group.")]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The Identity of the Office 365 Group")]
         public UnifiedGroupPipeBind Identity;
 
         protected override void ExecuteCmdlet()


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added ValueFromPipeline to allow for passing in filtered unified groups, fixed documentation errors as it is not possible to pass in multiple groups without doing a pipe unlike the help text suggested, added sample of using a pipe with the new ValueFromPipeLine to delete all public Office 365 Groups, removed unused usings to tidy up the code