### PR TITLE
Added support for SPFx app deployment for SP 2019 on premises

### DIFF
--- a/Commands/Apps/AddApp.cs
+++ b/Commands/Apps/AddApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.ALM;
 using OfficeDevPnP.Core.Enums;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
@@ -9,7 +9,7 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsCommon.Add, "PnPApp")]
     [CmdletHelp("Add/uploads an available app to the app catalog",
-        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online,
+        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019,
         OutputType = typeof(AppMetadata))]
     [CmdletExample(
         Code = @"PS:> Add-PnPApp -Path ./myapp.sppkg",

--- a/Commands/Apps/GetApp.cs
+++ b/Commands/Apps/GetApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
@@ -15,7 +15,7 @@ namespace SharePointPnP.PowerShell.Commands.Apps
     [Cmdlet(VerbsCommon.Get, "PnPApp")]
     [CmdletHelp("Returns the available apps from the app catalog",
         Category = CmdletHelpCategory.Apps,
-        OutputType = typeof(List<AppMetadata>), SupportedPlatform = CmdletSupportedPlatform.Online)]
+        OutputType = typeof(List<AppMetadata>), SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019)]
     [CmdletExample(
         Code = @"PS:> Get-PnPApp", 
         Remarks = @"This will return all available apps from the tenant app catalog. It will list the installed version in the current site.", 

--- a/Commands/Apps/InstallApp.cs
+++ b/Commands/Apps/InstallApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.ALM;
 using OfficeDevPnP.Core.Enums;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
@@ -11,7 +11,7 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsLifecycle.Install, "PnPApp")]
     [CmdletHelp("Installs an available app from the app catalog",
-        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online)]
+        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019)]
     [CmdletExample(
         Code = @"PS:> Install-PnPApp -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe",
         Remarks = @"This will install an app that is available in the tenant scoped app catalog, specified by the id, to the current site.",

--- a/Commands/Apps/PublishApp.cs
+++ b/Commands/Apps/PublishApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.Enums;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
@@ -9,7 +9,7 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsData.Publish, "PnPApp")]
     [CmdletHelp("Publishes/Deploys/Trusts an available app in the app catalog",
-        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online)]
+        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019)]
     [CmdletExample(
         Code = @"PS:> Publish-PnPApp -Identity 2646ccc3-6a2b-46ef-9273-81411cbbb60f", 
         Remarks = @"This will deploy/trust an app into the app catalog. Notice that the app needs to be available in the tenant scoped app catalog", SortOrder = 1)]

--- a/Commands/Apps/RemoveApp.cs
+++ b/Commands/Apps/RemoveApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.Enums;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
@@ -8,7 +8,7 @@ using System.Management.Automation;
 namespace SharePointPnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsCommon.Remove, "PnPApp")]
-    [CmdletHelp("Removes an app from the app catalog", SupportedPlatform = CmdletSupportedPlatform.Online,
+    [CmdletHelp("Removes an app from the app catalog", SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019,
         Category = CmdletHelpCategory.Apps)]
     [CmdletExample(
         Code = @"PS:> Remove-PnPApp -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe",

--- a/Commands/Apps/UnpublishApp.cs
+++ b/Commands/Apps/UnpublishApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.Enums;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
@@ -9,7 +9,7 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsData.Unpublish, "PnPApp")]
     [CmdletHelp("Unpublishes/retracts an available add-in from the app catalog",
-        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online)]
+        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019)]
     [CmdletExample(
         Code = @"PS:> Unpublish-PnPApp -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe",
         Remarks = @"This will retract, but not remove, the specified app from the tenant app catalog",

--- a/Commands/Apps/UpdateApp.cs
+++ b/Commands/Apps/UpdateApp.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.ALM;
 using OfficeDevPnP.Core.Enums;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
@@ -10,10 +10,10 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsData.Update, "PnPApp")]
     [CmdletHelp("Updates an available app from the app catalog",
-        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online)]
+        Category = CmdletHelpCategory.Apps, SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019)]
     [CmdletExample(
-        Code = @"PS:> Update-PnPApp -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe", 
-        Remarks = @"This will update an already installed app if a new version is available in the tenant app catalog. Retrieve a list all available apps and the installed and available versions with Get-PnPApp", 
+        Code = @"PS:> Update-PnPApp -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe",
+        Remarks = @"This will update an already installed app if a new version is available in the tenant app catalog. Retrieve a list all available apps and the installed and available versions with Get-PnPApp",
         SortOrder = 1)]
     [CmdletExample(
         Code = @"PS:> Update-PnPApp -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe -Scope Site",

--- a/Commands/Base/PipeBinds/AppMetadataPipeBind.cs
+++ b/Commands/Base/PipeBinds/AppMetadataPipeBind.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.ALM;
 using OfficeDevPnP.Core.Enums;


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
requires https://github.com/SharePoint/PnP-Sites-Core/pull/2074, partially implements #1812

## What is in this Pull Request ? ##
This pull request enables the SPFx app specific Cmdlets for SharePoint 2019. The groundwork was done in PR https://github.com/SharePoint/PnP-Sites-Core/pull/2074 and that PR has to be merged, before this PR can be processed.
