### PR TITLE
Dev addpnpalert

### DIFF
--- a/Commands/Principals/AddAlert.cs
+++ b/Commands/Principals/AddAlert.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Lists
+{
+    [Cmdlet(VerbsCommon.Add, "PnPAlert")]
+    [CmdletHelp("Adds an alert for a user to a list",
+        Category = CmdletHelpCategory.Principals,
+        OutputType = typeof(AlertCreationInformation),
+        OutputTypeLink = "https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.alertcreationinformation.aspx")]
+    [CmdletExample(
+        Code = @"Add-PnPAlert -List ""Demo List""",
+        Remarks = @"Adds a new alert to the ""Demo List"" for the current user.",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = @"Add-PnPAlert -Title ""Daily summary"" -List ""Demo List"" -Frequency Daily -ChangeType All -Time (Get-Date -Hour 11 -Minute 00 -Second 00)",
+        Remarks = @"Adds a daily alert for the current user at the given time to the ""Demo List"". Note: sometimes timezone offsets are applied to the Time so please verify on your tenant that the alert indeed got the right time.",
+        SortOrder = 2)]
+    [CmdletExample(
+        Code = @"Add-PnPAlert -Title ""Alert for user"" -List ""Demo List"" -Identity ""i:0#.f|membership|Alice@contoso.onmicrosoft.com""",
+        Remarks = @"Adds a new alert for user ""Alice"" to the ""Demo List"". Note: Only site owners and admins are permitted to set alerts for other users.",
+        SortOrder = 3)]
+    public class AddAlert : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]
+        public ListPipeBind List;
+
+        [Parameter(Mandatory = false, HelpMessage = "Alert title")]
+        public string Title { get; set; } = "Alert";
+
+        [Parameter(Mandatory = false, HelpMessage = "User to create the alert for (User ID, login name or actual User object). Skip this parameter to create an alert for the current user. Note: Only site owners can create alerts for other users.")]
+        public UserPipeBind Identity;
+
+        [Parameter(Mandatory = false, HelpMessage = "Alert delivery method")]
+        public AlertDeliveryChannel DeliveryMethod { get; set; } = AlertDeliveryChannel.Email;
+
+        [Parameter(Mandatory = false, HelpMessage = "Alert change type")]
+        public AlertEventType ChangeType { get; set; } = AlertEventType.All;
+
+        [Parameter(Mandatory = false, HelpMessage = "Alert frequency")]
+        public AlertFrequency Frequency { get; set; } = AlertFrequency.Immediate;
+
+        [Parameter(Mandatory = false, HelpMessage = @"Alert filter. Note: The values ""0"", ""1"", ""2"" and ""3"" correspond to the menu entries in the SharePoint UI for creating new alerts.")]
+        public string Filter;
+
+        [Parameter(Mandatory = false, HelpMessage = "Alert time (if frequency is not immediate)")]
+        public DateTime Time { get; set; } = DateTime.MinValue;
+
+        private User GetUserFromPipeBind()
+        {
+            if (Identity == null)
+            {
+                return null;
+            }
+
+            // note: the following code to get the user is copied from Remove-PnPUser - it could be put into a utility class
+            var retrievalExpressions = new Expression<Func<User, object>>[]
+            {
+                u => u.Id,
+                u => u.LoginName,
+                u => u.Email
+            };
+
+            User user = null;
+            if (Identity.User != null)
+            {
+                WriteVerbose($"Received user instance {Identity.Login}");
+                user = Identity.User;
+            }
+            else if (Identity.Id > 0)
+            {
+                WriteVerbose($"Retrieving user by Id {Identity.Id}");
+                user = ClientContext.Web.GetUserById(Identity.Id);
+            }
+            else if (!string.IsNullOrWhiteSpace(Identity.Login))
+            {
+                WriteVerbose($"Retrieving user by LoginName {Identity.Login}");
+                user = ClientContext.Web.SiteUsers.GetByLoginName(Identity.Login);
+            }
+            if (ClientContext.HasPendingRequest)
+            {
+                ClientContext.Load(user, retrievalExpressions);
+                ClientContext.ExecuteQueryRetry();
+            }
+
+            return user;
+        }
+
+        protected override void ExecuteCmdlet()
+        {
+            List list = null;
+            if (List != null)
+            {
+                list = List.GetList(SelectedWeb);
+            }
+            if (list != null)
+            {
+                var alert = new AlertCreationInformation();
+
+                User user;
+                if (null != Identity)
+                {
+                    user = GetUserFromPipeBind();
+                    if (user == null)
+                    {
+                        throw new ArgumentException("Unable to find user", "Identity");
+                    }
+                }
+                else
+                {
+                    user = SelectedWeb.CurrentUser;
+                }
+
+                alert.AlertFrequency = Frequency;
+                alert.AlertType = AlertType.List;
+                alert.AlwaysNotify = false;
+                alert.DeliveryChannels = DeliveryMethod;
+                alert.Filter = Filter;
+
+                if (!string.IsNullOrWhiteSpace(Filter))
+                {
+                    if (int.TryParse(Filter, out int filterIndex) && filterIndex >= 0 && filterIndex <= 3)
+                    {
+                        // setting the value of Filter sometimes does not work (CSOM < Jan 2017, ...?), so we use a known workaround
+                        // reference: http://toddbaginski.com/blog/how-to-create-office-365-sharepoint-alerts-with-the-client-side-object-model-csom/
+                        var properties = new Dictionary<string, string>()
+                        {
+                            { "FilterIndex", Filter }
+                            //Send Me an alert when:
+                            // 0 = Anything Changes
+                            // 1 = Someone else changes a document
+                            // 2 = Someone else changes a document created by me
+                            // 3 = Someone else changes a document modified by me
+                        };
+                        alert.Properties = properties;
+                    }
+                }
+
+                alert.List = list;
+                alert.Status = AlertStatus.On;
+                alert.Title = Title;
+                alert.User = user;
+                alert.EventType = ChangeType;
+                if (Time != DateTime.MinValue)
+                {
+                    alert.AlertTime = Time;
+                }
+
+                user.Alerts.Add(alert);
+                ClientContext.ExecuteQueryRetry();
+                WriteObject(alert);
+            }
+            else
+            {
+                throw new ArgumentException("Unable to find list", "List");
+            }
+        }
+    }
+}

--- a/Commands/Principals/AddAlert.cs
+++ b/Commands/Principals/AddAlert.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !ONPREMISES
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Management.Automation;
@@ -162,3 +163,4 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         }
     }
 }
+#endif

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -620,6 +620,7 @@
     <Compile Include="Model\SPOTheme.cs" />
     <Compile Include="Model\TokenResult.cs" />
     <Compile Include="ClientSidePages\ExportClientSidePage.cs" />
+    <Compile Include="Principals\AddAlert.cs" />
     <Compile Include="Provisioning\Tenant\ApplyTenantTemplate.cs" />
     <Compile Include="Provisioning\Tenant\ReadTenantTemplate.cs" />
     <Compile Include="Provisioning\Tenant\SaveTenantTemplate.cs" />

--- a/Tests/WebTests.cs
+++ b/Tests/WebTests.cs
@@ -156,7 +156,7 @@ namespace SharePointPnP.PowerShell.Tests
 
 #if !ONPREMISES
         [TestMethod]
-        public void AddAlert_WithDefaultProperties()
+        public void AddAlert_WithDefaultProperties_Test()
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
@@ -214,7 +214,7 @@ namespace SharePointPnP.PowerShell.Tests
 
 #if !ONPREMISES
         [TestMethod]
-        public void AddAlert_WithNonDefaultProperties()
+        public void AddAlert_WithNonDefaultProperties_Test()
         {
             using (var ctx = TestCommon.CreateClientContext())
             {

--- a/Tests/WebTests.cs
+++ b/Tests/WebTests.cs
@@ -153,5 +153,126 @@ namespace SharePointPnP.PowerShell.Tests
                 }
             }
         }
+
+        [TestMethod]
+        public void AddAlert_WithDefaultProperties()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                ctx.Web.EnsureProperties(w => w.CurrentUser.Id, w => w.CurrentUser.LoginName);
+                var currentUser = ctx.Web.CurrentUser;
+                var randomizer = new Random();
+                var randomAlertTitle = randomizer.Next(int.MaxValue).ToString();
+                var list = ctx.Web.DefaultDocumentLibrary();
+                list.EnsureProperties(l => l.Id);
+                var listId = list.Id;
+
+                // Execute cmd-let
+                using (var scope = new PSTestScope(true))
+                {
+                    var results = scope.ExecuteCommand("Add-PnPAlert",
+                        new CommandParameter("List", listId),
+                        new CommandParameter("Title", randomAlertTitle));
+                    Assert.IsNotNull(results);
+                    Assert.IsTrue(results.Count > 0);
+                    Assert.IsTrue(results[0].BaseObject.GetType() == typeof(Microsoft.SharePoint.Client.AlertCreationInformation));
+                    var alertInfo = results[0].BaseObject as AlertCreationInformation;
+                    Assert.AreEqual(randomAlertTitle, alertInfo.Title);
+                }
+
+                // now get actual alert and check properties
+                ctx.Web.EnsureProperties(w => w.CurrentUser.Alerts);
+                var newAlerts = currentUser.Alerts.Where(a => a.Title == randomAlertTitle);
+                Assert.AreEqual(1, newAlerts.Count(), "Unexpected number of created alerts");
+                var newAlert = newAlerts.First();
+                newAlert.User.EnsureProperties(u => u.LoginName);
+                newAlert.List.EnsureProperties(l => l.Id);
+                ctx.ExecuteQueryRetry();
+
+                try
+                {
+                    Assert.AreEqual(AlertFrequency.Immediate, newAlert.AlertFrequency);
+                    Assert.AreEqual(AlertDeliveryChannel.Email, newAlert.DeliveryChannels);
+                    Assert.AreEqual(AlertEventType.All, newAlert.EventType);
+                    Assert.AreEqual(AlertStatus.On, newAlert.Status);
+                    Assert.AreEqual(AlertType.List, newAlert.AlertType);
+                    Assert.AreEqual(currentUser.LoginName, newAlert.User.LoginName);
+                    Assert.AreEqual(listId, newAlert.List.Id);
+                    Assert.AreEqual("", newAlert.Filter);
+                }
+                finally
+                {
+                    // delete alert
+                    currentUser.Alerts.DeleteAlert(newAlert.ID);
+                    currentUser.Update();
+                    ctx.ExecuteQueryRetry();
+                }
+            }
+        }
+
+        [TestMethod]
+        public void AddAlert_WithNonDefaultProperties()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                ctx.Web.EnsureProperties(w => w.CurrentUser.Id, w => w.CurrentUser.LoginName);
+                var currentUser = ctx.Web.CurrentUser;
+                // generate random alert title
+                var randomizer = new Random();
+                var alertTitle = randomizer.Next(int.MaxValue).ToString();
+                var list = ctx.Web.DefaultDocumentLibrary();
+                list.EnsureProperties(l => l.Id);
+                var listId = list.Id;
+
+                // Execute cmd-let
+                using (var scope = new PSTestScope(true))
+                {
+                    var results = scope.ExecuteCommand("Add-PnPAlert",
+                        new CommandParameter("List", "Shared Documents"),
+                        new CommandParameter("Title", alertTitle),
+                        new CommandParameter("DeliveryMethod", AlertDeliveryChannel.Email), // cannot use SmS without having Frequency set to "Immediate"
+                        new CommandParameter("ChangeType", AlertEventType.DeleteObject),
+                        new CommandParameter("Frequency", AlertFrequency.Weekly),
+                        new CommandParameter("Time", new DateTime(2019, 01, 02, 03, 04, 05)),
+                        new CommandParameter("Filter", "1")
+                        );
+                    Assert.IsNotNull(results);
+                    Assert.IsTrue(results.Count > 0);
+                }
+
+                // now delete alert again
+                ctx.Web.EnsureProperties(w => w.CurrentUser.Alerts);
+                var newAlerts = currentUser.Alerts.Where(a => a.Title == alertTitle);
+                Assert.AreEqual(1, newAlerts.Count(), "Unexpected number of created alerts");
+                var newAlert = newAlerts.First();
+                newAlert.EnsureProperty(a => a.AlertTime);
+                newAlert.EnsureProperty(a => a.Properties);
+                newAlert.User.EnsureProperties(u => u.LoginName);
+                newAlert.List.EnsureProperties(l => l.Id);
+                ctx.ExecuteQueryRetry();
+
+                try
+                {
+                    Assert.AreEqual(AlertFrequency.Weekly, newAlert.AlertFrequency);
+                    Assert.AreEqual(AlertDeliveryChannel.Email, newAlert.DeliveryChannels);
+                    Assert.AreEqual(AlertEventType.DeleteObject, newAlert.EventType);
+                    Assert.AreEqual(AlertStatus.On, newAlert.Status);
+                    Assert.AreEqual(AlertType.List, newAlert.AlertType);
+                    Assert.AreEqual(currentUser.LoginName, newAlert.User.LoginName);
+                    Assert.AreEqual(listId, newAlert.List.Id);
+                    Assert.AreEqual(new DateTime(2019, 01, 02, 03, 04, 05), newAlert.AlertTime);
+                    Assert.AreEqual(1, newAlert.Properties.Count, "Unexpected number of properties");
+                    Assert.IsTrue(newAlert.Properties.ContainsKey("filterindex"));
+                    Assert.AreEqual("1", newAlert.Properties["filterindex"]);
+                }
+                finally
+                {
+                    // delete alert
+                    currentUser.Alerts.DeleteAlert(newAlert.ID);
+                    currentUser.Update();
+                    ctx.ExecuteQueryRetry();
+                }
+            }
+        }
     }
 }

--- a/Tests/WebTests.cs
+++ b/Tests/WebTests.cs
@@ -154,6 +154,7 @@ namespace SharePointPnP.PowerShell.Tests
             }
         }
 
+#if !ONPREMISES
         [TestMethod]
         public void AddAlert_WithDefaultProperties()
         {
@@ -209,7 +210,9 @@ namespace SharePointPnP.PowerShell.Tests
                 }
             }
         }
+#endif
 
+#if !ONPREMISES
         [TestMethod]
         public void AddAlert_WithNonDefaultProperties()
         {
@@ -274,5 +277,6 @@ namespace SharePointPnP.PowerShell.Tests
                 }
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1890 

## What is in this Pull Request ? ##
* adding new cmdlet `Add-PnPAlert` to add alerts to lists (SPO only)

## Notes ##
Several decisions could be challenged:
* the cmdlet is only available in SPO since the user's "Alerts" property seems to be absent on-prem (looking at `Get-PnPUser` I see a comparable restriction when getting properties of a user)
* the cmdlet is in the `Principals` category and not the `Lists` category since alerts are tied to users
* the cmdlet returns the `AlertCreationInformation` and not the actual alert, which would need another roundtrip to the server
* there is no unit test for assigning a task to another user as this would complicate test setup (need two users and a context switch)
* I did not add other cmdlets (Get-, Delete- etc.) since this can easily be done via the `User.Alerts` collection; and I want to wait for feedback first if the whole thing goes in the right direction