### PR TITLE
Permission Get cmdlets for existing Set cmdlets

### DIFF
--- a/Commands/Lists/GetListItemPermission.cs
+++ b/Commands/Lists/GetListItemPermission.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Lists
+{
+    [Cmdlet(VerbsCommon.Get, "PnPListItemPermission", DefaultParameterSetName = "User")]
+    [CmdletHelp("Get list item permissions",
+        Category = CmdletHelpCategory.Lists)]
+    [CmdletExample(
+        Code = "PS:> Get-PnPListItemPermission -List 'Documents' -Identity 1 -User 'user@contoso.com'",
+        Remarks = "This will return the permissions for the user 'user@contoso.com' and listitem with id 1 in the list 'Documents'",
+        SortOrder = 1)]
+    [CmdletExample(
+        Code = "PS:> Get-PnPListItemPermission -List 'Documents' -Identity 1",
+        Remarks = "This will return the permissions for listitem with id 1 in the list 'Documents'",
+        SortOrder = 2)]
+    public class GetListItemPermission : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public ListPipeBind List;
+
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The ID of the listitem, or actual ListItem object", ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public ListItemPipeBind Identity;
+
+        [Parameter(Mandatory = true, ParameterSetName = "Group")]
+        public GroupPipeBind Group;
+
+        [Parameter(Mandatory = true, ParameterSetName = "User")]
+        public string User;
+
+        protected override void ExecuteCmdlet()
+        {
+            List list = null;
+            if (List != null)
+            {
+                list = List.GetList(SelectedWeb);
+            }
+            if (list != null)
+            {
+                var item = Identity.GetListItem(list);
+                if (item != null)
+                {
+                    Principal principal = null;
+                    if (ParameterSetName == "Group")
+                    {
+                        if (Group.Id != -1)
+                        {
+                            principal = SelectedWeb.SiteGroups.GetById(Group.Id);
+                        }
+                        else if (!string.IsNullOrEmpty(Group.Name))
+                        {
+                            principal = SelectedWeb.SiteGroups.GetByName(Group.Name);
+                        }
+                        else if (Group.Group != null)
+                        {
+                            principal = Group.Group;
+                        }
+                    }
+                    else
+                    {
+                        principal = SelectedWeb.EnsureUser(User);
+                        ClientContext.ExecuteQueryRetry();
+                    }
+                    if (principal != null)
+                    {
+                        var roleAssignment = item.RoleAssignments.GetByPrincipal(principal);
+                        var roleDefinitionBindings = roleAssignment.RoleDefinitionBindings;
+                        foreach (var role in roleDefinitionBindings)
+                        {
+                            WriteObject(role, true);
+                        }
+                    }
+                    else
+                    {
+                        var roleAssignment = item.RoleAssignments;
+                        var roleDefinitionBindings = roleAssignment.RoleDefinitionBindings;
+                        foreach (var role in roleDefinitionBindings)
+                        {
+                            WriteObject(role, true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Commands/Lists/GetListPermission.cs
+++ b/Commands/Lists/GetListPermission.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Lists
+{
+    //TODO: Create Test
+    [Cmdlet(VerbsCommon.Get, "PnPListPermission")]
+    [CmdletHelp("Get list permissions",
+        Category = CmdletHelpCategory.Lists)]
+    [CmdletExample(
+        Code = "PS:> Get-PnPListPermission -Identity 'Documents' -User 'user@contoso.com' -AddRole 'Contribute'",
+        Remarks = "This will return the permissions to the user 'user@contoso.com' for the list 'Documents'",
+        SortOrder = 1)]        
+    [CmdletExample(
+        Code = "PS:> Get-PnPListPermission -Identity 'Documents' -User 'user@contoso.com' -RemoveRole 'Contribute'",
+        Remarks = "This will return the permissions to the user 'user@contoso.com' for the list 'Documents'",
+        SortOrder = 2)]        
+    public class GetListPermission : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ParameterSetName = ParameterAttribute.AllParameterSets, HelpMessage = "The ID or Title of the list.")]
+        public ListPipeBind Identity;
+
+        [Parameter(Mandatory = false, ParameterSetName = "Group")]
+        public GroupPipeBind Group;
+
+        [Parameter(Mandatory = false, ParameterSetName = "User")]
+        public string User;
+
+        protected override void ExecuteCmdlet()
+        {
+            var list = Identity.GetList(SelectedWeb);
+
+            if (list != null)
+            {
+                Principal principal = null;
+                if (ParameterSetName == "Group")
+                {
+                    if (Group.Id != -1)
+                    {
+                        principal = SelectedWeb.SiteGroups.GetById(Group.Id);
+                    }
+                    else if (!string.IsNullOrEmpty(Group.Name))
+                    {
+                        principal = SelectedWeb.SiteGroups.GetByName(Group.Name);
+                    }
+                    else if (Group.Group != null)
+                    {
+                        principal = Group.Group;
+                    }
+                }
+                else
+                {
+                    principal = SelectedWeb.EnsureUser(User);
+                    ClientContext.ExecuteQueryRetry();
+                }
+                if (principal != null)
+                {
+                    var roleAssignment = list.RoleAssignments.GetByPrincipal(principal);
+                    var roleDefinitionBindings = roleAssignment.RoleDefinitionBindings;
+                    foreach (var role in roleDefinitionBindings)
+                    {
+                        WriteObject(role, true);
+                    }
+                }
+                else
+                {
+                    var roleAssignment = list.RoleAssignments;
+                    var roleDefinitionBindings = roleAssignment.RoleDefinitionBindings;
+                    foreach (var role in roleDefinitionBindings)
+                    {
+                        WriteObject(role, true);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Commands/Web/GetWebPermission.cs
+++ b/Commands/Web/GetWebPermission.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using SharePointPnP.PowerShell.Commands.Extensions;
+
+namespace SharePointPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Get, "PnPWebPermission", DefaultParameterSetName = "User")]
+    [CmdletHelp("Get permissions",
+        "Get web permissions",
+        Category = CmdletHelpCategory.Webs)]
+    [CmdletExample(
+        Code = "PS:> Get-PnPWebPermission -Url projectA",
+        Remarks = "This will return the permissions for a web, specified by its site relative url",
+        SortOrder = 1)] 
+    [CmdletExample(
+        Code = "PS:> Get-PnPWebPermission -Url projectA -User 'user@contoso.com'",
+        Remarks = "This will return the permissions for the user 'user@contoso.com' for a web, specified by its site relative url",
+        SortOrder = 2)]        
+    [CmdletExample(
+        Code = "PS:> Get-PnPWebPermission -Identity 5fecaf67-6b9e-4691-a0ff-518fc9839aa0 -User 'user@contoso.com'",
+        Remarks = "This will return the permissions for the user 'user@contoso.com' for a web, specified by its ID",
+        SortOrder = 3)]        
+    public class GetWebPermission : PnPWebCmdlet
+    {
+		[Parameter(Mandatory = true, HelpMessage = "Identity/Id/Web object", ParameterSetName = "GroupByWebIdentity", ValueFromPipeline = true)]
+		[Parameter(Mandatory = true, HelpMessage = "Identity/Id/Web object", ParameterSetName = "UserByWebIdentity", ValueFromPipeline = true)]
+		public WebPipeBind Identity;
+
+		[Parameter(Mandatory = true, HelpMessage = "The site relative url of the web, e.g. 'Subweb1'", ParameterSetName = "GroupByWebUrl")]
+		[Parameter(Mandatory = true, HelpMessage = "The site relative url of the web, e.g. 'Subweb1'", ParameterSetName = "UserByWebUrl")]
+		public string Url;
+
+		[Parameter(Mandatory = false, ParameterSetName = "Group")]
+		[Parameter(Mandatory = false, ParameterSetName = "GroupByWebIdentity")]
+		[Parameter(Mandatory = false, ParameterSetName = "GroupByWebUrl")]
+		public GroupPipeBind Group;
+
+        [Parameter(Mandatory = false, ParameterSetName = "User")]
+        [Parameter(Mandatory = false, ParameterSetName = "UserByWebIdentity")]
+        [Parameter(Mandatory = false, ParameterSetName = "UserByWebUrl")]
+        public string User;
+
+
+        protected override void ExecuteCmdlet()
+		{
+			// Get Web
+			Web web = SelectedWeb;
+			if (ParameterSetName == "GroupByWebIdentity" || ParameterSetName == "UserByWebIdentity")
+			{
+				if (Identity.Id != Guid.Empty)
+				{
+					web = ClientContext.Web.GetWebById(Identity.Id);
+				}
+				else if (Identity.Web != null)
+				{
+					web = Identity.Web;
+				}
+				else if (Identity.Url != null)
+				{
+					web = ClientContext.Web.GetWebByUrl(Identity.Url);
+				}
+			}
+			else if (ParameterSetName == "GroupByWebUrl" || ParameterSetName == "UserByWebUrl")
+			{
+				web = SelectedWeb.GetWeb(Url);
+			}
+
+			// Get permissions
+			Principal principal = null;
+			if (ParameterSetName == "Group" || ParameterSetName == "GroupByWebUrl" || ParameterSetName == "GroupByWebIdentity")
+			{
+				if (Group.Id != -1)
+				{
+					principal = web.SiteGroups.GetById(Group.Id);
+				}
+				else if (!string.IsNullOrEmpty(Group.Name))
+				{
+					principal = web.SiteGroups.GetByName(Group.Name);
+				}
+				else if (Group.Group != null)
+				{
+					principal = Group.Group;
+				}
+			}
+			else
+			{
+				principal = web.EnsureUser(User);
+			}
+
+			// Principal
+			if (principal != null)
+			{
+				foreach (var role in web.RoleAssigments)
+				{
+					// Filter to Principal
+					if (role.Member == principal) {
+						WriteObject(role, true);
+					}
+				}
+			}
+			else
+			{
+				foreach (var role in web.RoleAssigments)
+				{
+					// Filter to Principal
+					WriteObject(role, true);
+					
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [X ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #X, partially fixes #Y, mentioned in #Z, etc.

## What is in this Pull Request ? ##
Please describe the changes in the PR. 

Currently PNP has 4 cmdlets to SET permissions and only 1 for GET:  

Set-PnPGroupPermissions
Set-PnPListItemPermission
Set-PnPListPermission
Set-PnPWebPermission

Get-PnPGroupPermissions

PR to add 3 more GET cmdlets:

Get-PnPListItemPermission
Get-PnPListPermission
Get-PnPWebPermission
