### PR TITLE
Fixing GetAzureADCredentialsContext not available on prem issue

### DIFF
--- a/Commands/Base/SPOnlineConnection.cs
+++ b/Commands/Base/SPOnlineConnection.cs
@@ -176,8 +176,8 @@ namespace SharePointPnP.PowerShell.Commands.Base
                     context.ExecuteQueryRetry();
                 }
                 catch (Exception ex)
-
                 {
+#if !ONPREMISES && !NETSTANDARD2_0
                     if (ex is WebException || ex is NotSupportedException)
                     {
                         // legacy auth?
@@ -187,8 +187,11 @@ namespace SharePointPnP.PowerShell.Commands.Base
                     }
                     else
                     {
+#endif
                         throw;
+#if !ONPREMISES && !NETSTANDARD2_0
                     }
+#endif
                 }
                 ContextCache.Add(context);
             }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixing GetAzureADCredentialsContext not available in on premises thus the code not compiling in SharePoint 2019 mode