### PR TITLE
Feature : Added support for HubSiteId and Owners while groupifying site

### DIFF
--- a/Commands/Admin/AddOffice365GroupToSite.cs
+++ b/Commands/Admin/AddOffice365GroupToSite.cs
@@ -5,6 +5,7 @@ using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base;
 using System.Management.Automation;
 using OfficeDevPnP.Core.Sites;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace SharePointPnP.PowerShell.Commands.Admin
 {
@@ -39,8 +40,13 @@ namespace SharePointPnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false, HelpMessage = @"Specifies if the current site home page is kept. Defaults to false.")]
         public SwitchParameter KeepOldHomePage;
 
+        [Parameter(Mandatory = false, HelpMessage = "If specified the site will be associated to the hubsite as identified by this id")]
+        public GuidPipeBind HubSiteId;
+
+        [Parameter(Mandatory = false, HelpMessage = "The array UPN values of the group's owners.")]
+        public string[] Owners;
         protected override void ExecuteCmdlet()
-        {
+        {            
             var groupifyInformation = new TeamSiteCollectionGroupifyInformation()
             {
                 Alias = Alias,
@@ -48,8 +54,14 @@ namespace SharePointPnP.PowerShell.Commands.Admin
                 Description = Description,
                 Classification = Classification,
                 IsPublic = IsPublic,
-                KeepOldHomePage = KeepOldHomePage
+                KeepOldHomePage = KeepOldHomePage,
+                Owners = Owners
             };
+
+            if (MyInvocation.BoundParameters.ContainsKey("HubSiteId"))
+            {
+                groupifyInformation.HubSiteId = HubSiteId.Id;
+            }
 
             Tenant.GroupifySite(Url, groupifyInformation);
         }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Depends on PR https://github.com/SharePoint/PnP-Sites-Core/pull/2114 

## What is in this Pull Request ? ##
This PR adds the ability to specify HubSiteId property as well as additional owners when groupify-ing the site collection. 

It depends on the above mentioned PR in the PnP Sites core repository to be merged before this PR is merged in the PnP PowerShell repository
