### PR TITLE
Feature : Added support for Creating MS Teams while provisioning/modifying groups

### DIFF
--- a/Commands/Graph/NewUnifiedGroup.cs
+++ b/Commands/Graph/NewUnifiedGroup.cs
@@ -56,6 +56,9 @@ namespace SharePointPnP.PowerShell.Commands.Graph
         [Parameter(Mandatory = false, HelpMessage = "The path to the logo file of to set.")]
         public string GroupLogoPath;
 
+        [Parameter(Mandatory = false, HelpMessage = "Creates a MS Teams team associated with created group.")]
+        public SwitchParameter CreateTeam;
+
         [Parameter(Mandatory = false, HelpMessage = "Specifying the Force parameter will skip the confirmation question.")]
         public SwitchParameter Force;
 
@@ -85,14 +88,15 @@ namespace SharePointPnP.PowerShell.Commands.Graph
             if (forceCreation)
             {
                 var group = UnifiedGroupsUtility.CreateUnifiedGroup(
-                    DisplayName,
-                    Description,
-                    MailNickname,
-                    AccessToken,
-                    Owners,
-                    Members,
-                    GroupLogoPath,
-                    IsPrivate);
+                    displayName: DisplayName,
+                    description: Description,
+                    mailNickname: MailNickname,
+                    accessToken: AccessToken,
+                    owners: Owners,
+                    members: Members,
+                    groupLogoPath: GroupLogoPath,
+                    isPrivate: IsPrivate,
+                    createTeam: CreateTeam);
 
                 WriteObject(group);
             }

--- a/Commands/Graph/SetUnifiedGroup.cs
+++ b/Commands/Graph/SetUnifiedGroup.cs
@@ -56,6 +56,9 @@ namespace SharePointPnP.PowerShell.Commands.Graph
         [Parameter(Mandatory = false, HelpMessage = "The path to the logo file of to set.")]
         public string GroupLogoPath;
 
+        [Parameter(Mandatory = false, HelpMessage = "Creates a MS Teams team associated with created group.")]
+        public SwitchParameter CreateTeam;
+
         protected override void ExecuteCmdlet()
         {
             UnifiedGroupEntity group = null;
@@ -78,12 +81,20 @@ namespace SharePointPnP.PowerShell.Commands.Graph
                     groupLogoStream = new FileStream(GroupLogoPath, FileMode.Open, FileAccess.Read);
                 }
                 bool? isPrivateGroup = null;
-                if(IsPrivate.IsPresent)
+                if (IsPrivate.IsPresent)
                 {
                     isPrivateGroup = IsPrivate.ToBool();
                 }
-                UnifiedGroupsUtility.UpdateUnifiedGroup(group.GroupId, AccessToken, displayName: DisplayName,
-                    description: Description, owners: Owners, members: Members, groupLogo: groupLogoStream, isPrivate: isPrivateGroup);
+                UnifiedGroupsUtility.UpdateUnifiedGroup(
+                    groupId: group.GroupId,
+                    accessToken: AccessToken,
+                    displayName: DisplayName,
+                    description: Description,
+                    owners: Owners,
+                    members: Members,
+                    groupLogo: groupLogoStream,
+                    isPrivate: isPrivateGroup,
+                    createTeam: CreateTeam);
             }
             else
             {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##

Added support to optionally create MS Teams team while provisioning O365 group as well as while modifying the group's properties.
Also, added named parameters in the methods for better readability, clarity and to reduce ambiguity as I was initially a bit confused while testing this out. Please remove it if not needed :) 