### PR TITLE
Do not rely on Userprofil to be loaded when importing PnPAzureCertifi…

### DIFF
--- a/Commands/Base/GetAzureCertificate.cs
+++ b/Commands/Base/GetAzureCertificate.cs
@@ -47,7 +47,7 @@ PrivateKey contains the PEM encoded private key of the certificate.",
                 CertificatePath = Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, CertificatePath);
             }
 
-            var certificate = new X509Certificate2(CertificatePath, CertificatePassword, X509KeyStorageFlags.Exportable);
+            var certificate = new X509Certificate2(CertificatePath, CertificatePassword, (X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet));
             var rawCert = certificate.GetRawCertData();
             var base64Cert = Convert.ToBase64String(rawCert);
             var rawCertHash = certificate.GetCertHash();


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
In some Scripting-Enviroments the profile (inculding its certificate-store) of the executing user is not load. This results in error "The system cannot find the file specified." when calling X509Certificate2-Constructor.
Calling this constructor with additional Flag "X509KeyStorageFlags.MachineKeySet" fixes this issue.