### PR TITLE
Fix: Support for ClientSideComponentId while adding custom action in SP 2019

### DIFF
--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -126,7 +126,7 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
             }
             else
             {
-#if !ONPREMISES
+#if !SP2013 && !SP2016
                 ca = new CustomActionEntity()
                 {
                     Name = Name,


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2019 

## What is in this Pull Request ? ##

Fixed the issue of adding User custom action for SP 2019 with ClientSideComponentId.
While we changed the compiler directives for ClientSideComponentId and ClientSideComponentProperties, looks like we missed it in the command execution.