### PR TITLE
Feature: Add support for Organization News site commands

### DIFF
--- a/Commands/Admin/GetOrgNewsSite.cs
+++ b/Commands/Admin/GetOrgNewsSite.cs
@@ -1,0 +1,26 @@
+﻿#if !ONPREMISES
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+using System.Management.Automation;
+
+namespace SharePointPnP.PowerShell.Commands.Admin
+{
+    [Cmdlet(VerbsCommon.Get, "PnPOrgNewsSite")]
+    [CmdletHelp("Returns the list of all the configured organizational news sites.",
+     SupportedPlatform = CmdletSupportedPlatform.Online,
+     Category = CmdletHelpCategory.TenantAdmin)]
+    [CmdletExample(
+     Code = @"PS:> Get-PnPOrgNewsSite",
+     Remarks = @"Returns the list of all the configured organizational news sites.", SortOrder = 1)]
+    public class GetOrgNewsSite : PnPAdminCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            var results = Tenant.GetOrgNewsSites();
+            ClientContext.ExecuteQueryRetry();
+            WriteObject(results, true);
+        }
+    }
+}
+#endif

--- a/Commands/Admin/RemoveOrgNewsSite.cs
+++ b/Commands/Admin/RemoveOrgNewsSite.cs
@@ -1,0 +1,31 @@
+﻿#if !ONPREMISES
+using Microsoft.Online.SharePoint.TenantAdministration;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+using System.Management.Automation;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Admin
+{
+    [Cmdlet(VerbsCommon.Remove, "PnPOrgNewsSite")]    
+    [CmdletHelp("Removes a given site from the list of organizational news sites.",
+        DetailedDescription = @"Removes a given site from the list of organizational news sites based on its URL in your Sharepoint Online Tenant.",
+        SupportedPlatform = CmdletSupportedPlatform.Online,
+        Category = CmdletHelpCategory.TenantAdmin)]
+    [CmdletExample(
+        Code = @"PS:> Remove-PnPOrgNewsSite -OrgNewsSiteUrl https://tenant.sharepoint.com/sites/mysite",
+        Remarks = @"This example removes the specified site from list of organization's news sites.", SortOrder = 1)]
+    public class RemoveOrgNewsSite : PnPAdminCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = @"The site to be removed from list of organization's news sites")]
+        public SitePipeBind OrgNewsSiteUrl;
+
+        protected override void ExecuteCmdlet()
+        {
+            Tenant.RemoveOrgNewsSite(OrgNewsSiteUrl.Url);
+            ClientContext.ExecuteQueryRetry();
+        }
+    }
+}
+#endif

--- a/Commands/Admin/SetOrgNewsSite.cs
+++ b/Commands/Admin/SetOrgNewsSite.cs
@@ -1,0 +1,29 @@
+﻿#if !ONPREMISES
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+using System.Management.Automation;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.Admin
+{
+    [Cmdlet(VerbsCommon.Set, "PnPOrgNewsSite")]
+    [CmdletHelp("Sets the site as an organization news site in your tenant",
+     SupportedPlatform = CmdletSupportedPlatform.Online,
+     Category = CmdletHelpCategory.TenantAdmin)]
+    [CmdletExample(
+     Code = @"PS:> Set-PnPOrgNewsSite -OrgNewsSiteUrl https://yourtenant.sharepoint.com/sites/news",
+     Remarks = @"Sets the site as one of multiple possible tenant's organizational news sites", SortOrder = 1)]
+    public class SetOrgNewsSite : PnPAdminCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "The url of the site to be marked as one of organization's news sites")]
+        public SitePipeBind OrgNewsSiteUrl;
+
+        protected override void ExecuteCmdlet()
+        {
+            Tenant.SetOrgNewsSite(OrgNewsSiteUrl.Url);
+            ClientContext.ExecuteQueryRetry();
+        }
+    }
+}
+#endif

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -540,6 +540,9 @@
     <Compile Include="Admin\AddTenantTheme.cs" />
     <Compile Include="Admin\GetHomeSite.cs" />
     <Compile Include="Admin\EnableCommSite.cs" />
+    <Compile Include="Admin\GetOrgNewsSite.cs" />
+    <Compile Include="Admin\RemoveOrgNewsSite.cs" />
+    <Compile Include="Admin\SetOrgNewsSite.cs" />
     <Compile Include="Base\InvokeSPRestMethod.cs" />
     <Compile Include="Admin\RemoveHomeSite.cs" />
     <Compile Include="Admin\SetHomeSite.cs" />


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##

This PR adds the commandlets necessary for Organization news sites.

It adds the ability to mark a site collection as organization's authoritative news site collection, ability to list all such site collection and also to remove the site collection as organization's news site collection