### PR TITLE
Added new flag DisableFormsBasedAuthentication

### DIFF
--- a/Commands/Apps/AddApp.cs
+++ b/Commands/Apps/AddApp.cs
@@ -55,7 +55,7 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
             var bytes = System.IO.File.ReadAllBytes(Path);
 
-            var manager = new AppManager(ClientContext);
+            var manager = new AppManager(ClientContext, GetAdditionalHeaders());
 
             var result = manager.Add(bytes, fileInfo.Name, Overwrite, Scope, timeoutSeconds: Timeout);
 

--- a/Commands/Apps/GetApp.cs
+++ b/Commands/Apps/GetApp.cs
@@ -38,11 +38,12 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-            var manager = new AppManager(ClientContext);
+            var additionalHeaders = GetAdditionalHeaders();
+            var manager = new AppManager(ClientContext, additionalHeaders);
 
             if (MyInvocation.BoundParameters.ContainsKey("Identity"))
             {
-                var app = Identity.GetAppMetadata(ClientContext, Scope);
+                var app = Identity.GetAppMetadata(ClientContext, Scope, additionalHeaders);
                 if (app != null)
                 {
                     WriteObject(app);

--- a/Commands/Apps/InstallApp.cs
+++ b/Commands/Apps/InstallApp.cs
@@ -6,6 +6,7 @@ using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 using System;
 using System.Management.Automation;
 using System.Threading;
+using SharePointPnP.PowerShell.Commands.Base;
 
 namespace SharePointPnP.PowerShell.Commands.Apps
 {
@@ -41,9 +42,10 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-            var manager = new AppManager(ClientContext);
+            var additionalHeaders = GetAdditionalHeaders();
+            var manager = new AppManager(ClientContext, additionalHeaders);
 
-            var app = Identity.GetAppMetadata(ClientContext, Scope);
+            var app = Identity.GetAppMetadata(ClientContext, Scope, additionalHeaders);
             if (app != null)
             {
                 manager.Install(app, Scope);

--- a/Commands/Apps/PublishApp.cs
+++ b/Commands/Apps/PublishApp.cs
@@ -29,9 +29,10 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-            var manager = new OfficeDevPnP.Core.ALM.AppManager(ClientContext);
+            var additionalHeaders = GetAdditionalHeaders();
+            var manager = new OfficeDevPnP.Core.ALM.AppManager(ClientContext, additionalHeaders);
 
-            var app = Identity.GetAppMetadata(ClientContext, Scope);
+            var app = Identity.GetAppMetadata(ClientContext, Scope, additionalHeaders);
             if (app != null)
             {
                 manager.Deploy(app, SkipFeatureDeployment, Scope);

--- a/Commands/Apps/RemoveApp.cs
+++ b/Commands/Apps/RemoveApp.cs
@@ -26,9 +26,10 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-            var manager = new OfficeDevPnP.Core.ALM.AppManager(ClientContext);
+            var additionalHeaders = GetAdditionalHeaders();
+            var manager = new OfficeDevPnP.Core.ALM.AppManager(ClientContext, additionalHeaders);
 
-            var app = Identity.GetAppMetadata(ClientContext, Scope);
+            var app = Identity.GetAppMetadata(ClientContext, Scope, additionalHeaders);
 
             if (app != null)
             {

--- a/Commands/Apps/UnpublishApp.cs
+++ b/Commands/Apps/UnpublishApp.cs
@@ -28,9 +28,10 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-            var manager = new OfficeDevPnP.Core.ALM.AppManager(ClientContext);
+            var additionalHeaders = GetAdditionalHeaders();
+            var manager = new OfficeDevPnP.Core.ALM.AppManager(ClientContext, additionalHeaders);
 
-            var app = Identity.GetAppMetadata(ClientContext, Scope);
+            var app = Identity.GetAppMetadata(ClientContext, Scope, additionalHeaders);
             if (app != null)
             {
                 manager.Retract(app, Scope);

--- a/Commands/Apps/UpdateApp.cs
+++ b/Commands/Apps/UpdateApp.cs
@@ -29,8 +29,9 @@ namespace SharePointPnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-            var manager = new AppManager(ClientContext);
-            var app = Identity.GetAppMetadata(ClientContext, Scope);
+            var additionalHeaders = GetAdditionalHeaders();
+            var manager = new AppManager(ClientContext, additionalHeaders);
+            var app = Identity.GetAppMetadata(ClientContext, Scope, additionalHeaders);
             if (app != null)
             {
                 manager.Upgrade(Identity.Id, Scope);

--- a/Commands/Base/PipeBinds/AppMetadataPipeBind.cs
+++ b/Commands/Base/PipeBinds/AppMetadataPipeBind.cs
@@ -3,6 +3,7 @@ using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.ALM;
 using OfficeDevPnP.Core.Enums;
 using System;
+using System.Collections.Generic;
 
 namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
 {
@@ -35,9 +36,9 @@ namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
 
         public string Title => _title;
 
-        public AppMetadata GetAppMetadata(ClientContext context, AppCatalogScope scope)
+        public AppMetadata GetAppMetadata(ClientContext context, AppCatalogScope scope, Dictionary<string, string> additionalHeaders)
         {
-            var appmanager = new AppManager(context);
+            var appmanager = new AppManager(context, additionalHeaders);
             if (_id != Guid.Empty)
             {
                 return appmanager.GetAvailable(_id, scope);

--- a/Commands/Base/PnPCmdlet.cs
+++ b/Commands/Base/PnPCmdlet.cs
@@ -124,5 +124,20 @@ namespace SharePointPnP.PowerShell.Commands
         {
             base.EndProcessing();
         }
+
+        /// <summary>
+        /// Computes additional headers for REST API calls that have to be included during composition of the request
+        /// </summary>
+        /// <returns><see cref="Dictionary{TKey,TValue}"/> that contains the key and value of the additional headers</returns>
+        protected virtual Dictionary<string, string> GetAdditionalHeaders()
+        {
+            var additionalHeaders = new Dictionary<string, string>();
+            if (SPOnlineConnection.CurrentConnection.DisableFormsBasedAuthentication)
+            {
+                additionalHeaders.Add("X-FORMS_BASED_AUTH_ACCEPTED", "f");
+            }
+
+            return additionalHeaders;
+        }
     }
 }

--- a/Commands/Base/SPOnlineConnection.cs
+++ b/Commands/Base/SPOnlineConnection.cs
@@ -30,6 +30,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
         public static TokenResult TokenResult { get; set; }
         public static SPOnlineConnection CurrentConnection { get; internal set; }
         public ConnectionType ConnectionType { get; protected set; }
+        public bool DisableFormsBasedAuthentication { get; protected set; }
         public InitializationType InitializationType { get; protected set; }
         public int MinimalHealthScore { get; protected set; }
         public int RetryCount { get; protected set; }
@@ -93,7 +94,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
             }
         }
 
-        internal SPOnlineConnection(ClientContext context, ConnectionType connectionType, int minimalHealthScore, int retryCount, int retryWait, PSCredential credential, string url, string tenantAdminUrl, string pnpVersionTag, System.Management.Automation.Host.PSHost host, bool disableTelemetry, InitializationType initializationType)
+        internal SPOnlineConnection(ClientContext context, ConnectionType connectionType, int minimalHealthScore, int retryCount, int retryWait, PSCredential credential, string url, string tenantAdminUrl, string pnpVersionTag, System.Management.Automation.Host.PSHost host, bool disableTelemetry, InitializationType initializationType, bool disableFormsBasedAuthentication = false)
         {
             if (!disableTelemetry)
             {
@@ -115,6 +116,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
             PnPVersionTag = pnpVersionTag;
             Url = (new Uri(url)).AbsoluteUri;
             ConnectionMethod = ConnectionMethod.Credentials;
+            DisableFormsBasedAuthentication = disableFormsBasedAuthentication;
         }
 
         internal SPOnlineConnection(ClientContext context, TokenResult tokenResult, ConnectionType connectionType, int minimalHealthScore, int retryCount, int retryWait, PSCredential credential, string url, string tenantAdminUrl, string pnpVersionTag, PSHost host, bool disableTelemetry, InitializationType initializationType)

--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -593,7 +593,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
                     connectionType = ConnectionType.TenantAdmin;
                 }
             }
-            var spoConnection = new SPOnlineConnection(context, connectionType, minimalHealthScore, retryCount, retryWait, credentials, url.ToString(), tenantAdminUrl, PnPPSVersionTag, host, disableTelemetry, InitializationType.Credentials);
+            var spoConnection = new SPOnlineConnection(context, connectionType, minimalHealthScore, retryCount, retryWait, credentials, url.ToString(), tenantAdminUrl, PnPPSVersionTag, host, disableTelemetry, InitializationType.Credentials, disableFormsBasedAuthentication);
             spoConnection.ConnectionMethod = Model.ConnectionMethod.Credentials;
             return spoConnection;
         }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #808, requires https://github.com/SharePoint/PnP-Sites-Core/pull/2230

## What is in this Pull Request ? ##
Optionally disables Forms Based Authentication with a new `DisableFormsBasedAuthentication` flag when using On Prem SharePoint with additional claims providers. This flag sets the `X-FORMS_BASED_AUTH_ACCEPTED` flag to `f`, so that forms based authentication is disabled.
This PR requires the Pull Request https://github.com/SharePoint/PnP-Sites-Core/pull/2230, because for REST based calls, new web requests are constructed in the PnP-Sites-Core project that also need the new flag.