### PR TITLE
Avoiding nullreference exception with Get-PnPWebTemplates

### DIFF
--- a/Commands/Base/SPOnlineConnection.cs
+++ b/Commands/Base/SPOnlineConnection.cs
@@ -178,7 +178,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
                 catch (Exception ex)
                 {
 #if !ONPREMISES && !NETSTANDARD2_0
-                    if (ex is WebException || ex is NotSupportedException)
+                    if ((ex is WebException || ex is NotSupportedException) && CurrentConnection.PSCredential != null)
                     {
                         // legacy auth?
                         var authManager = new OfficeDevPnP.Core.AuthenticationManager();


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
When connecting to the non admin part of SharePoint Online, i.e. https://koenzomers.sharepoint.com using -WebLogin to deal with two factor authentication, then running Get-PnPWebTemplates, it would throw a fuzzy NullReference exception. This is because it tries to clone the context to the koenzomers-admin.sharepoint.com URL as it concerns an admin cmdlet. This fails because it used the WebLogin. It then tries to create a new security context using the CurrentConnection.PSCredential, but that is NULL with a WebLogin thus a NullReference exception gets thrown. This fix at least ensures a 401 unauthorized gets thrown instead of a NullReference exception. Still not ideal, but not sure under what circumstances I could avoid the rethrow of the exception so the clear "You are not in admin mode" exception gets returned. This is at least better than it was already.