### PR TITLE
Use DefaultNetworkCredentials if the current credentials should be used

### DIFF
--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -562,6 +562,12 @@ namespace SharePointPnP.PowerShell.Commands.Base
                 {
                     context.Credentials = new NetworkCredential(credentials.UserName, credentials.Password);
                 }
+                else
+                {
+                    // If current credentials should be used, use the DefaultNetworkCredentials of the CredentialCache. This has the same effect
+                    // as using "UseDefaultCredentials" in a HttpClient.
+                    context.Credentials = CredentialCache.DefaultNetworkCredentials;
+                }
             }
 #if SP2013 || SP2016 || SP2019
             var connectionType = ConnectionType.OnPrem;


### PR DESCRIPTION
## Type ##

- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##

This issue has been discovered while using PR #2068 in our Azure DevOps scripts for an on premises environment.

## What is in this Pull Request ? ##

If a script is started with CurrentCredentials, the Credentials object of the context is empty. This causes an issue with REST based calls that construct their own `HttpClient `, as the `UseDefaultCredentials` flag on each instance of the `HttpClient` has to be set. As an alternative, the Credentials object can be set on the context to the `CredentialCache.DefaultNetworkCredentials` which is the same as using the `UseDefaultCredentials` flag.