### PR TITLE
Allow for SPFx Application Extension deployment through CustomAction on SP2019

### DIFF
--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -32,13 +32,13 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         private const string ParameterSet_DEFAULT = "Default";
         private const string ParameterSet_CLIENTSIDECOMPONENTID = "Client Side Component Id";
         [Parameter(Mandatory = true, HelpMessage = "The name of the custom action", ParameterSetName = ParameterSet_DEFAULT)]
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         [Parameter(Mandatory = true, HelpMessage = "The name of the custom action", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
 #endif
         public string Name = string.Empty;
 
         [Parameter(Mandatory = true, HelpMessage = "The title of the custom action", ParameterSetName = ParameterSet_DEFAULT)]
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         [Parameter(Mandatory = true, HelpMessage = "The title of the custom action", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
 #endif
         public string Title = string.Empty;
@@ -50,7 +50,7 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         public string Group = string.Empty;
 
         [Parameter(Mandatory = true, HelpMessage = "The actual location where this custom action need to be added like 'CommandUI.Ribbon'", ParameterSetName = ParameterSet_DEFAULT)]
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         [Parameter(Mandatory = true, HelpMessage = "The actual location where this custom action need to be added like 'CommandUI.Ribbon'", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
 #endif
         public string Location = string.Empty;

--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -126,7 +126,7 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
             }
             else
             {
-#if !ONPREMISES
+#if !SP2013 && !SP2016
                 ca = new CustomActionEntity()
                 {
                     Name = Name,


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Additional changes to allow for SPFx Application Extensions which are deployed tenant wide to be enabled on individual sites through adding a CustomAction using PnP PowerShell on SharePoint 2019.

Test this by creating a new Application Extension and running:

Add-PnPCustomAction -Name "Test" -Title "Test" -Location "ClientSideExtension.ApplicationCustomizer" -ClientSideComponentId <guid from manifest json>

It should now show the dialog on every modern page of the site where you connected to.