### PR TITLE
Ignore url case in Get-PnPFolder when comparing input url with Web Se…

### DIFF
--- a/Commands/Files/GetFolder.cs
+++ b/Commands/Files/GetFolder.cs
@@ -43,7 +43,7 @@ namespace SharePointPnP.PowerShell.Commands.Files
             DefaultRetrievalExpressions = new Expression<Func<Folder, object>>[] { f => f.ServerRelativeUrl, f => f.Name, f => f.ItemCount };
 #endif
             var webServerRelativeUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
-            if (!Url.ToLower().StartsWith(webServerRelativeUrl))
+            if (!Url.StartsWith(webServerRelativeUrl, StringComparison.OrdinalIgnoreCase))
             {
                 Url = UrlUtility.Combine(webServerRelativeUrl, Url);
             }


### PR DESCRIPTION
Ignore url casing in Get-PnPFolder when comparing input url with Web ServerRelativeUrl

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No related issues

## What is in this Pull Request ? ##
Get-PnPFolder builds a Server Relative Url from the input Url and the current Web Server Relative Url.
If the input Url doesn't start with the Web Url, then Web Url is inserted at the beginning (Web Url + Input Url).
This PR fixes a bug where the input Url would be set ToLower() but the Web Server Relative Url would be kept as returned from SP, making the comparision fail if the Web had uppercase letters.

The comparision uses StringComparison.OrdinalIgnoreCase (same as the one used in SharePointPnP.PowerShell.Commands.Utilities.REST.RestHelper for example at https://github.com/SharePoint/PnP-PowerShell/blob/master/Commands/Utilities/REST/RestHelper.cs#L24 )