### PR TITLE
Feature: Add ability to reset inheritance of a SharePoint list

### DIFF
--- a/Commands/Lists/SetList.cs
+++ b/Commands/Lists/SetList.cs
@@ -94,13 +94,16 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         [Parameter(Mandatory = false, HelpMessage = "Enable or disable whether content approval is enabled for the list. Set to $true to enable, $false to disable.")]
         public bool EnableModeration;
 
+        [Parameter(Mandatory = false, HelpMessage = "If used the security inheritance is reset for this list")]
+        public SwitchParameter InheritPermissions;
+
         protected override void ExecuteCmdlet()
         {
             var list = Identity.GetList(SelectedWeb);
 
             if (list != null)
             {
-                list.EnsureProperties(l => l.EnableAttachments, l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.EnableModeration, l => l.BaseType);
+                list.EnsureProperties(l => l.EnableAttachments, l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.EnableModeration, l => l.BaseType, l => l.ContentTypesEnabled);
 
                 var enableVersioning = list.EnableVersioning;
                 var enableMinorVersions = list.EnableMinorVersions;
@@ -112,6 +115,16 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 {
                     list.BreakRoleInheritance(CopyRoleAssignments, ClearSubscopes);
                     isDirty = true;
+                }
+
+                if (InheritPermissions)
+                {
+                    list.EnsureProperty(l => l.HasUniqueRoleAssignments);
+                    if (list.HasUniqueRoleAssignments)
+                    {
+                        list.ResetRoleInheritance();
+                        isDirty = true;
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(Title))
@@ -189,9 +202,6 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 }
                 isDirty = false;
 
-
-
-
                 if (list.EnableVersioning)
                 {
                     // list or doclib?
@@ -219,8 +229,6 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                             isDirty = true;
                         }
                     }
-
-
                 }
                 if (isDirty)
                 {

--- a/Commands/Lists/SetList.cs
+++ b/Commands/Lists/SetList.cs
@@ -94,7 +94,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         [Parameter(Mandatory = false, HelpMessage = "Enable or disable whether content approval is enabled for the list. Set to $true to enable, $false to disable.")]
         public bool EnableModeration;
 
-        [Parameter(Mandatory = false, HelpMessage = "If used the security inheritance is reset for this list")]
+        [Parameter(Mandatory = false, HelpMessage = "If used, the security inheritance is reset for this list and will inherit permissions of the current web.")]
         public SwitchParameter InheritPermissions;
 
         protected override void ExecuteCmdlet()
@@ -111,11 +111,6 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 var enableAttachments = list.EnableAttachments;
 
                 var isDirty = false;
-                if (BreakRoleInheritance)
-                {
-                    list.BreakRoleInheritance(CopyRoleAssignments, ClearSubscopes);
-                    isDirty = true;
-                }
 
                 if (InheritPermissions)
                 {
@@ -126,6 +121,12 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                         isDirty = true;
                     }
                 }
+
+                if (BreakRoleInheritance)
+                {
+                    list.BreakRoleInheritance(CopyRoleAssignments, ClearSubscopes);
+                    isDirty = true;
+                }                
 
                 if (!string.IsNullOrEmpty(Title))
                 {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##

Fixes #2153 

## What is in this Pull Request ? ##

Added capability to reset list inheritance. 
Also added `ContentTypesEnabled` property in the ensure properties method, as it is used in the code but not initialised.