### PR TITLE
Added two Connect-PnPOnline options for AAD Apps using certificates

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -121,15 +121,15 @@ PS:> Connect-PnPOnline -Url https://yourserver -ClientId <id> -HighTrustCertific
 #if !ONPREMISES
     [CmdletExample(
        Code = "PS:> Connect-PnPOnline -ClientId <id> -CertificatePath 'c:\\mycertificate.pfx' -CertificatePassword (ConvertTo-SecureString -AsPlainText 'myprivatekeypassword' -Force) -Url https://contoso.sharepoint.com -Tenant 'contoso.onmicrosoft.com'",
-       Remarks = "Connects using an Azure Active Directory registered appliation using a locally available certificate containing a private key. See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.",
+       Remarks = "Connects using an Azure Active Directory registered application using a locally available certificate containing a private key. See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.",
        SortOrder = 16)]
     [CmdletExample(
        Code = "PS:> Connect-PnPOnline -ClientId <id> -CertificateBase64Encoded 'xxxx' -CertificatePassword (ConvertTo-SecureString -AsPlainText 'myprivatekeypassword' -Force) -Url https://contoso.sharepoint.com -Tenant 'contoso.onmicrosoft.com'",
-       Remarks = "Connects using an Azure Active Directory registered appliation using a certificate containing a private key encoded in base 64 such as received in an Azure Function when using Azure KeyVault. See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.",
+       Remarks = "Connects using an Azure Active Directory registered application using a certificate containing a private key encoded in base 64 such as received in an Azure Function when using Azure KeyVault. See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.",
        SortOrder = 17)]
     [CmdletExample(
        Code = "PS:> Connect-PnPOnline -ClientId <id> -Certificate $cert -CertificatePassword (ConvertTo-SecureString -AsPlainText 'myprivatekeypassword' -Force) -Url https://contoso.sharepoint.com -Tenant 'contoso.onmicrosoft.com'",
-       Remarks = "Connects using an Azure Active Directory registered appliation using a certificate instance containing a private key. See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.",
+       Remarks = "Connects using an Azure Active Directory registered application using a certificate instance containing a private key. See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.",
        SortOrder = 18)]
 
 #endif

--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -378,8 +378,14 @@ PS:> Connect-PnPOnline -Url https://yourserver -ClientId <id> -HighTrustCertific
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_APPONLYAAD, HelpMessage = "The Azure AD Tenant name,e.g. mycompany.onmicrosoft.com")]
         public string Tenant;
 
-        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_APPONLYAAD, HelpMessage = "Path to the certificate (*.pfx)")]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_APPONLYAAD, HelpMessage = "Path to the certificate (*.pfx)")]
         public string CertificatePath;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_APPONLYAAD, HelpMessage = "Base64 Encoded X509Certificate2 containing the private key to authenticate the requests to SharePoint Online such as retrieved in Azure Functions from Azure KeyVault")]
+        public string CertificateBase64Encoded;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_APPONLYAAD, HelpMessage = "X509Certificate2 containing the private key to authenticate the requests to SharePoint Online")]
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_APPONLYAAD, HelpMessage = "Password to the certificate (*.pfx)")]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_APPONLYAADPEM, HelpMessage = "Password to the certificate (*.pfx)")]
@@ -566,7 +572,19 @@ Use -PnPO365ManagementShell instead");
             else if (ParameterSetName == ParameterSet_APPONLYAAD)
             {
 #if !NETSTANDARD2_0
-                connection = SPOnlineConnectionHelper.InitiateAzureADAppOnlyConnection(new Uri(Url), ClientId, Tenant, CertificatePath, CertificatePassword, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, Host, NoTelemetry, SkipTenantAdminCheck, AzureEnvironment);
+                if (MyInvocation.BoundParameters.ContainsKey("CertificatePath"))
+                {
+                    connection = SPOnlineConnectionHelper.InitiateAzureADAppOnlyConnection(new Uri(Url), ClientId, Tenant, CertificatePath, CertificatePassword, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, Host, NoTelemetry, SkipTenantAdminCheck, AzureEnvironment);
+                } else if (MyInvocation.BoundParameters.ContainsKey("Certificate"))
+                {
+                    connection = SPOnlineConnectionHelper.InitiateAzureAdAppOnlyConnectionWithCert(new Uri(Url), ClientId, Tenant, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, Host, NoTelemetry, SkipTenantAdminCheck, AzureEnvironment, Certificate);
+                } else if (MyInvocation.BoundParameters.ContainsKey("CertificateBase64Encoded"))
+                {
+                    connection = SPOnlineConnectionHelper.InitiateAzureAdAppOnlyConnectionWithCert(new Uri(Url), ClientId, Tenant, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, TenantAdminUrl, Host, NoTelemetry, SkipTenantAdminCheck, AzureEnvironment, CertificateBase64Encoded);
+                } else
+                {
+                    throw new Exception();
+                }
 #else
                 throw new NotImplementedException();
 #endif

--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -391,6 +391,57 @@ namespace SharePointPnP.PowerShell.Commands.Base
             return InitiateAzureAdAppOnlyConnectionWithCert(url, clientId, tenant, minimalHealthScore, retryCount, retryWait, requestTimeout, tenantAdminUrl, host, disableTelemetry, skipAdminCheck, azureEnvironment, certificate, true);
         }
 
+        /// <summary>
+        /// Takes a certificate encoded in Base64 such as retrieved from Azure KeyVault when using Azure Functions to authenticate to SharePoint
+        /// </summary>
+        /// <remarks>See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread how to set up a certificate which you can store in Azure KeyVault</remarks>
+        /// <param name="url">Url of the SharePoint site to connect to</param>
+        /// <param name="clientId">Application/client ID of the Azure Active Directory application registration</param>
+        /// <param name="tenant">Tenant name to connect to, i.e. contoso.onmicrosoft.com</param>
+        /// <param name="minimalHealthScore">Value between 0 and 10 indicating the health of the SharePoint server connected to should report before commands get executed where 0 is the healthiest and 10 the least healthy. I.e. if you set it to 3, SharePoint must report a health score of 0, 1, 2 or 3 before it will execute the commands. If set to -1, no health check will be performed.</param>
+        /// <param name="retryCount">Amount of times to retry an operation that i.e. times out or runs into health issues before giving up on it</param>
+        /// <param name="retryWait">Time in seconds to wait between retry attempts</param>
+        /// <param name="requestTimeout">Time in milliseconds to allow a command to complete before considering it failed</param>
+        /// <param name="tenantAdminUrl">Url of the admin site of the tenant. If not provided, it will assume to connect automatically to https://<tenantname>-admin.sharepoint.com.</param>
+        /// <param name="host">Reference to the PowerShell session in which the commands will be executed</param>
+        /// <param name="disableTelemetry">Boolean indicating whether or not telemetry should be disabled</param>
+        /// <param name="skipAdminCheck">Boolean indicating if it should check if the connection is being made to the Tenand admin site</param>
+        /// <param name="azureEnvironment">Type of Azure environment connecting to</param>
+        /// <param name="base64EncodedCertificate">Base64 encoded string containing the certificate which grants access to SharePoint Online</param>
+        /// <returns>A connection to SharePoint</returns>
+        internal static SPOnlineConnection InitiateAzureAdAppOnlyConnectionWithCert(Uri url, string clientId, string tenant,
+            int minimalHealthScore, int retryCount, int retryWait, int requestTimeout, string tenantAdminUrl, PSHost host, bool disableTelemetry,
+            bool skipAdminCheck, AzureEnvironment azureEnvironment, string base64EncodedCertificate)
+        {
+            X509Certificate2 certificate = CertificateHelper.GetCertificateFromBase64Encodedstring(base64EncodedCertificate);
+            return InitiateAzureAdAppOnlyConnectionWithCert(url, clientId, tenant, minimalHealthScore, retryCount, retryWait, requestTimeout, tenantAdminUrl, host, disableTelemetry, skipAdminCheck, azureEnvironment, certificate);
+        }
+
+        /// <summary>
+        /// Takes a certificate encoded in Base64 such as retrieved from Azure KeyVault when using Azure Functions to authenticate to SharePoint
+        /// </summary>
+        /// <remarks>See https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread how to set up a certificate which you can store in Azure KeyVault</remarks>
+        /// <param name="url">Url of the SharePoint site to connect to</param>
+        /// <param name="clientId">Application/client ID of the Azure Active Directory application registration</param>
+        /// <param name="tenant">Tenant name to connect to, i.e. contoso.onmicrosoft.com</param>
+        /// <param name="minimalHealthScore">Value between 0 and 10 indicating the health of the SharePoint server connected to should report before commands get executed where 0 is the healthiest and 10 the least healthy. I.e. if you set it to 3, SharePoint must report a health score of 0, 1, 2 or 3 before it will execute the commands. If set to -1, no health check will be performed.</param>
+        /// <param name="retryCount">Amount of times to retry an operation that i.e. times out or runs into health issues before giving up on it</param>
+        /// <param name="retryWait">Time in seconds to wait between retry attempts</param>
+        /// <param name="requestTimeout">Time in milliseconds to allow a command to complete before considering it failed</param>
+        /// <param name="tenantAdminUrl">Url of the admin site of the tenant. If not provided, it will assume to connect automatically to https://<tenantname>-admin.sharepoint.com.</param>
+        /// <param name="host">Reference to the PowerShell session in which the commands will be executed</param>
+        /// <param name="disableTelemetry">Boolean indicating whether or not telemetry should be disabled</param>
+        /// <param name="skipAdminCheck">Boolean indicating if it should check if the connection is being made to the Tenand admin site</param>
+        /// <param name="azureEnvironment">Type of Azure environment connecting to</param>
+        /// <param name="certificate">The X509Certificate2 which grants access to SharePoint Online</param>
+        /// <returns>A connection to SharePoint</returns>
+        internal static SPOnlineConnection InitiateAzureAdAppOnlyConnectionWithCert(Uri url, string clientId, string tenant,
+            int minimalHealthScore, int retryCount, int retryWait, int requestTimeout, string tenantAdminUrl, PSHost host, bool disableTelemetry,
+            bool skipAdminCheck, AzureEnvironment azureEnvironment, X509Certificate2 certificate)
+        {
+            return InitiateAzureAdAppOnlyConnectionWithCert(url, clientId, tenant, minimalHealthScore, retryCount, retryWait, requestTimeout, tenantAdminUrl, host, disableTelemetry, skipAdminCheck, azureEnvironment, certificate, false);
+        }
+
         private static SPOnlineConnection InitiateAzureAdAppOnlyConnectionWithCert(Uri url, string clientId, string tenant,
             int minimalHealthScore, int retryCount, int retryWait, int requestTimeout, string tenantAdminUrl, PSHost host, bool disableTelemetry,
             bool skipAdminCheck, AzureEnvironment azureEnvironment, X509Certificate2 certificate, bool certificateFromFile)

--- a/Commands/Utilities/CertificateHelper.cs
+++ b/Commands/Utilities/CertificateHelper.cs
@@ -113,6 +113,19 @@ namespace SharePointPnP.PowerShell.Commands.Utilities
             return null;
         }
 
+        /// <summary>
+        /// Converts a public key certificate stored in Base64 encoding such as retrieved from Azure KeyVault to a X509Certificate2
+        /// </summary>
+        /// <param name="publicCert">Public key certificate endoded with Base64</param>
+        /// <returns>X509Certificate2 certificate</returns>
+        internal static X509Certificate2 GetCertificateFromBase64Encodedstring(string publicCert)
+        {
+            var certificateBytes = Convert.FromBase64String(publicCert);
+            var certificate = new X509Certificate2(certificateBytes);
+
+            return certificate;
+        }
+
         internal static X509Certificate2 GetCertificateFromPEMstring(string publicCert, string privateKey, string password)
         {
             if (string.IsNullOrWhiteSpace(password)) password = "";

--- a/Commands/Web/SetWeb.cs
+++ b/Commands/Web/SetWeb.cs
@@ -9,7 +9,7 @@ namespace SharePointPnP.PowerShell.Commands
         Category = CmdletHelpCategory.Webs)]
     public class SetWeb : PnPWebCmdlet
     {
-        [Parameter(Mandatory = false, HelpMessage = "Sets the logo of the web to the current url. If you want to set the logo to a modern team site, use Set-PnPSite -SiteLogoPath")]
+        [Parameter(Mandatory = false, HelpMessage = "Sets the logo of the web to the current url. If you want to set the logo to a modern team site, use Set-PnPSite -LogoFilePath.")]
         public string SiteLogoUrl;
 
         [Parameter(Mandatory = false)]


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added two Connect-PnPOnline options using an application registerd in Azure Active Directory using a certificate. Useful i.e. when using PnP PowerShell in an Azure Function v1 and storing the certificate in an Azure KeyVault.

This one already existed before and is used in similar scenarios but requires having the certificate physically stored somewhere:
```powershell
Connect-PnPOnline -ClientId xxxx -CertificatePath "d:\xxxx.pfx" -CertificatePassword (ConvertTo-SecureString -AsPlainText "xxxx" -Force) -Url https://xxxx.sharepoint.com -Tenant "xxxx.onmicrosoft.com"
```

This one is new and particularly useful when using PnP PowerShell inside an Azure Function v1 and you store the certificate of your Azure Active Directory registration in Azure KeyVault through the way described [here](https://azure.microsoft.com/en-us/blog/simplifying-security-for-serverless-and-web-apps-with-azure-functions-and-app-service/): @Microsoft.KeyVault(SecretUri=secret_uri_with_version)

```powershell
Connect-PnPOnline -ClientId xxxx -CertificatePassword (ConvertTo-SecureString -AsPlainText "xxxx" -Force) -Url https://xxxx.sharepoint.com -Tenant "xxxx.onmicrosoft.com" -CertificateBase64Encoded "xxxx"
```

This one is also new and can be useful if you have some means of receiving the certificate from somewhere, i.e. in an Azure Function v2 using C# and .NET Core and using that to authenticate using an Azure Active Directory application registration and a certificate:
```powershell
$cert = Get-PfxCertificate d:\xxxx.pfx
Connect-PnPOnline -ClientId xxxx -CertificatePassword (ConvertTo-SecureString -AsPlainText "xxxx" -Force) -Url https://xxxx.sharepoint.com -Tenant "xxxx.onmicrosoft.com" -Certificate $cert
```

Also accidentally included in this PR is a small help argument update on Set-PnPWeb where it was referring to a Set-PnPSite argument which didn't exist. Would have been nicer to submit it under its own PR but got included in this one.