### PR TITLE
Added permissions required for each of the *-PnPUnifiedGroup* commands

### DIFF
--- a/Commands/Graph/GetUnifiedGroup.cs
+++ b/Commands/Graph/GetUnifiedGroup.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Get, "PnPUnifiedGroup")]
-    [CmdletHelp("Gets one Office 365 Group (aka Unified Group) or a list of Office 365 Groups",
+    [CmdletHelp("Gets one Office 365 Group (aka Unified Group) or a list of Office 365 Groups. Requires the Azure Active Directory application permission 'Group.Read.All'.",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(

--- a/Commands/Graph/GetUnifiedGroupMembers.cs
+++ b/Commands/Graph/GetUnifiedGroupMembers.cs
@@ -11,7 +11,7 @@ using System.Management.Automation;
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Get, "PnPUnifiedGroupMembers")]
-    [CmdletHelp("Gets members of a particular Office 365 Group (aka Unified Group)",
+    [CmdletHelp("Gets members of a particular Office 365 Group (aka Unified Group). Requires the Azure Active Directory application permissions 'Group.Read.All' and 'User.Read.All'.",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(

--- a/Commands/Graph/GetUnifiedGroupOwners.cs
+++ b/Commands/Graph/GetUnifiedGroupOwners.cs
@@ -11,7 +11,7 @@ using System.Management.Automation;
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Get, "PnPUnifiedGroupOwners")]
-    [CmdletHelp("Gets owners of a particular Office 365 Group (aka Unified Group)",
+    [CmdletHelp("Gets owners of a particular Office 365 Group (aka Unified Group). Requires the Azure Active Directory application permissions 'Group.Read.All' and 'User.Read.All'.",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(

--- a/Commands/Graph/NewUnifiedGroup.cs
+++ b/Commands/Graph/NewUnifiedGroup.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.New, "PnPUnifiedGroup")]
-    [CmdletHelp("Creates a new Office 365 Group (aka Unified Group)",
+    [CmdletHelp("Creates a new Office 365 Group (aka Unified Group). Requires the Azure Active Directory application permission 'Group.ReadWrite.All'.",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(

--- a/Commands/Graph/RemoveUnifiedGroup.cs
+++ b/Commands/Graph/RemoveUnifiedGroup.cs
@@ -8,7 +8,7 @@ using System.Management.Automation;
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Remove, "PnPUnifiedGroup")]
-    [CmdletHelp("Removes one Office 365 Group (aka Unified Group)",
+    [CmdletHelp("Removes one Office 365 Group (aka Unified Group). Requires the Azure Active Directory application permission 'Group.ReadWrite.All'.",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(

--- a/Commands/Graph/SetUnifiedGroup.cs
+++ b/Commands/Graph/SetUnifiedGroup.cs
@@ -10,7 +10,7 @@ using System.Management.Automation;
 namespace SharePointPnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Set, "PnPUnifiedGroup")]
-    [CmdletHelp("Sets Office 365 Group (aka Unified Group) properties",
+    [CmdletHelp("Sets Office 365 Group (aka Unified Group) properties. Requires the Azure Active Directory application permission 'Group.ReadWrite.All'.",
         Category = CmdletHelpCategory.Graph,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
     [CmdletExample(


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [X] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added to the help text of each of the *-PnPUnifiedGroup* commands the permissions it needs to have in Azure Active Directory to be able to perform the operation.