### PR TITLE
Fixing using Disconnect-PnPOnline after connecting to the Graph API

### DIFF
--- a/Commands/Base/DisconnectSPOnline.cs
+++ b/Commands/Base/DisconnectSPOnline.cs
@@ -53,26 +53,37 @@ namespace SharePointPnP.PowerShell.Commands.Base
         }
 
         internal static bool DisconnectProvidedService(SPOnlineConnection connection)
-        {
-            connection.AccessToken = string.Empty;
+        {            
             Environment.SetEnvironmentVariable("PNPPSHOST", string.Empty);
             Environment.SetEnvironmentVariable("PNPPSSITE", string.Empty);
             if (connection == null)
+            {
                 return false;
+            }
+            connection.AccessToken = string.Empty;
             connection.Context = null;
             connection = null;
             return true;
         }
 
         internal static bool DisconnectCurrentService()
-        {
-            SPOnlineConnection.CurrentConnection.AccessToken = string.Empty;
+        {            
             Environment.SetEnvironmentVariable("PNPPSHOST", string.Empty);
             Environment.SetEnvironmentVariable("PNPPSSITE", string.Empty);
-            if (SPOnlineConnection.CurrentConnection == null)
+            if (SPOnlineConnection.CurrentConnection == null && SPOnlineConnection.AuthenticationResult == null)
+            {
                 return false;
-            SPOnlineConnection.CurrentConnection.Context = null;
-            SPOnlineConnection.CurrentConnection = null;
+            }
+            if (SPOnlineConnection.CurrentConnection != null)
+            {
+                SPOnlineConnection.CurrentConnection.AccessToken = string.Empty;
+                SPOnlineConnection.CurrentConnection.Context = null;
+                SPOnlineConnection.CurrentConnection = null;
+            }
+            if (SPOnlineConnection.AuthenticationResult != null)
+            {
+                SPOnlineConnection.AuthenticationResult = null;
+            }
             return true;
         }
     }

--- a/Commands/Base/PnPGraphCmdlet.cs
+++ b/Commands/Base/PnPGraphCmdlet.cs
@@ -40,7 +40,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
 #endif
                     }
                 }
-                else if (SPOnlineConnection.CurrentConnection.AccessToken != null)
+                else if (SPOnlineConnection.CurrentConnection != null && SPOnlineConnection.CurrentConnection.AccessToken != null)
                 {
                     return SPOnlineConnection.CurrentConnection.AccessToken;
                 }

--- a/Commands/Base/TokenHandling.cs
+++ b/Commands/Base/TokenHandling.cs
@@ -9,6 +9,11 @@ namespace SharePointPnP.PowerShell.Commands.Base
     {
         internal static string AcquireToken(string resource, string scope = null)
         {
+            if(SPOnlineConnection.CurrentConnection == null)
+            {
+                return null;            
+            }
+
             var tenantId = TenantExtensions.GetTenantIdByUrl(SPOnlineConnection.CurrentConnection.Url);
 
             if (tenantId == null) return null;


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixing that using Disconnect-PnPOnline after using Connect-PnPOnline -AppId x -AppSecret x - AADDomain x.onmicrosoft.com actually works now and does not throw an exception and does do a disconnect