### PR TITLE
Fix creation of Calculated fields

### DIFF
--- a/Commands/Fields/AddField.cs
+++ b/Commands/Fields/AddField.cs
@@ -160,10 +160,12 @@ Remarks = @"This will add a field of type Multiple Choice to the list ""Demo Lis
                             };
                         }
 
+                        fieldCI.AdditionalChildNodes = new List<KeyValuePair<string, string>>()
+                        {
+                            new KeyValuePair<string, string>("Formula", calculatedFieldParameters.Formula)
+                        };
+
                         f = list.CreateField<FieldCalculated>(fieldCI);
-                        ((FieldCalculated)f).Formula = calculatedFieldParameters.Formula;
-                        f.Update();
-                        ClientContext.ExecuteQueryRetry();
                     }
                     else
                     {

--- a/Commands/Fields/AddField.cs
+++ b/Commands/Fields/AddField.cs
@@ -6,6 +6,7 @@ using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
 using System.Collections;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace SharePointPnP.PowerShell.Commands.Fields
 {
@@ -143,6 +144,22 @@ Remarks = @"This will add a field of type Multiple Choice to the list ""Demo Lis
                     }
                     else if (Type == FieldType.Calculated)
                     {
+                        // Either set the ResultType as input parameter or set it to the default Text
+                        if (!string.IsNullOrEmpty(calculatedFieldParameters.ResultType))
+                        {
+                            fieldCI.AdditionalAttributes = new List<KeyValuePair<string, string>>()
+                            {
+                                new KeyValuePair<string, string>("ResultType", calculatedFieldParameters.ResultType)
+                            };
+                        }
+                        else
+                        {
+                            fieldCI.AdditionalAttributes = new List<KeyValuePair<string, string>>()
+                            {
+                                new KeyValuePair<string, string>("ResultType", "Text")
+                            };
+                        }
+
                         f = list.CreateField<FieldCalculated>(fieldCI);
                         ((FieldCalculated)f).Formula = calculatedFieldParameters.Formula;
                         f.Update();
@@ -341,6 +358,9 @@ Remarks = @"This will add a field of type Multiple Choice to the list ""Demo Lis
         {
             [Parameter(Mandatory = true)]
             public string Formula;
+
+            [Parameter(Mandatory = false)]
+            public string ResultType;
         }
 
     }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1811 , #1488
Requires https://github.com/SharePoint/PnP-Sites-Core/pull/2373

## What is in this Pull Request ? ##
This Pull Request fix the creation of Calculated fields.
The Calculated field type requires a "\<Formula>" child node and a ResultType attribute in the CAML definition that the previous code didn't specify on the creation of the field but would try to set after. 
The Formula is mandatory on creation so the command would fail with an error message
![image](https://user-images.githubusercontent.com/1153754/63925102-c7802c00-ca49-11e9-94da-0ebdaadc3b85.png)

-ResultType optional parameter is added also, defaulting to "Text".

The Pull Request contains 2 commits, with the latest version targeting the latest version of https://github.com/SharePoint/PnP-Sites-Core/pull/2373

Here's a script to reproduce the issue and to test the Pull Request
```powershell
# Get credentials
$credentials = get-credential
$siteUrl = "<enter a SPO site collection url>"

$listName = "Test PR Calculated"
$fieldDisplayName = "Test calculated"
$fieldInternalName = "pnp_testcalculated"

Connect-PnPOnline -Url $siteUrl -Credentials $credentials
# Create a lists
New-PnPList -Title $listName -Template GenericList
# Add a Calcualted field
Add-PnPField -DisplayName $fieldDisplayName -InternalName $fieldInternalName -Type Calculated -List $listName -Formula '="Test"' #-ResultType "Text"
```