### PR TITLE
Feature: Added Reset-PnPLabel command

### DIFF
--- a/Commands/InformationManagement/ResetLabel.cs
+++ b/Commands/InformationManagement/ResetLabel.cs
@@ -1,0 +1,52 @@
+﻿#if !ONPREMISES
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+
+namespace SharePointPnP.PowerShell.Commands.InformationManagement
+{
+    [Cmdlet(VerbsCommon.Reset, "PnPLabel")]
+    [CmdletHelp("Resets a label/tag on the specified list or library to None", Category = CmdletHelpCategory.InformationManagement, SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+       Code = @"PS:> Reset-PnPLabel  -List ""Demo List""",
+       Remarks = @"This resets an O365 label on the specified list or library to None. ", SortOrder = 1)]
+    [CmdletExample(
+       Code = @"PS:> Reset-PnPLabel  -List ""Demo List"" -SyncToItems $true",
+       Remarks = @"This resets an O365 label on the specified list or library to None and resets the label on all the items in the list and library except Folders and where the label has been manually or previously automatically assigned.", SortOrder = 2)]
+
+    public class ResetListComplianceTag : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID or Url of the list.")]
+        public ListPipeBind List;
+
+        [Parameter(Mandatory = false, HelpMessage = "Reset label on existing items in the library.")]
+        public bool SyncToItems;
+
+        protected override void ExecuteCmdlet()
+        {
+            var list = List.GetList(SelectedWeb);
+            if (list != null)
+            {
+                var listUrl = list.RootFolder.ServerRelativeUrl;
+                Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.SetListComplianceTag(ClientContext, listUrl, string.Empty, false, false, SyncToItems);
+
+                try
+                {
+                    ClientContext.ExecuteQueryRetry();
+                }
+                catch (System.Exception error)
+                {
+                    WriteWarning(error.Message.ToString());
+                }
+
+            }
+            else
+            {
+                WriteWarning("List or library not found.");
+
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
https://github.com/SharePoint/PnP-PowerShell/issues/2175

## What is in this Pull Request ? ##
A new Reset-PnPLabel command to set the compliance tag on a List or Library to blank / None.  Optionally this command can clear the compliance tag from items in the list / library however it will only clear items that aren't a Folder, have had the label applied manually, or been auto-applied previously.  I.E. This will only clear labels that have been set by the Set-PnPLabel command.