### PR TITLE
Feature: Add (retention) Label parameter to Add/Set-PnPListItem

### DIFF
--- a/Commands/Lists/AddListItem.cs
+++ b/Commands/Lists/AddListItem.cs
@@ -38,6 +38,12 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Code = @"Add-PnPListItem -List ""Demo List"" -Values @{""Title""=""Sales Report""} -Folder ""projects/europe""",
         Remarks = @"Adds a new list item to the ""Demo List"". It will add the list item to the europe folder which is located in the projects folder. Folders will be created if needed.",
         SortOrder = 3)]
+#if !ONPREMISES
+    [CmdletExample(
+        Code = @"Add-PnPListItem -List ""Demo List"" -Values @{""Title""=""Sales Report""} -Label ""Public""",
+        Remarks = @"Adds a new list item to the ""Demo List"". Sets the retention label to ""Public"" if it exists on the site.",
+        SortOrder = 4)]
+#endif
     public class AddListItem : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]
@@ -70,6 +76,11 @@ namespace SharePointPnP.PowerShell.Commands.Lists
 
         [Parameter(Mandatory = false, HelpMessage = @"The list relative URL of a folder. E.g. ""MyFolder"" for a folder located in the root of the list, or ""MyFolder/SubFolder"" for a folder located in the MyFolder folder which is located in the root of the list.")]
         public string Folder;
+
+#if !ONPREMISES
+        [Parameter(Mandatory = false, HelpMessage = "The name of the retention label.")]
+        public String Label;
+#endif
 
         protected override void ExecuteCmdlet()
         {
@@ -132,6 +143,25 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                             ThrowTerminatingError(new ErrorRecord(new Exception(terminatingErrorMessage), terminatingErrorCode, ErrorCategory.InvalidData, this));
                         });
                 }
+
+#if !ONPREMISES
+                if (!String.IsNullOrEmpty(Label))
+                {
+                    IList<Microsoft.SharePoint.Client.CompliancePolicy.ComplianceTag> tags = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(ClientContext, ClientContext.Url);
+                    ClientContext.ExecuteQueryRetry();
+
+                    var tag = tags.Where(t => t.TagName == Label).FirstOrDefault();
+
+                    if (tag != null)
+                    {
+                        item.SetComplianceTag(tag.TagName, tag.BlockDelete, tag.BlockEdit, tag.IsEventTag, tag.SuperLock);
+                    }
+                    else
+                    {
+                        WriteWarning("Can not find compliance tag with value: " + Label);
+                    }
+                }
+#endif
 
                 item.Update();
                 ClientContext.Load(item);

--- a/Commands/Lists/AddListItem.cs
+++ b/Commands/Lists/AddListItem.cs
@@ -38,12 +38,10 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Code = @"Add-PnPListItem -List ""Demo List"" -Values @{""Title""=""Sales Report""} -Folder ""projects/europe""",
         Remarks = @"Adds a new list item to the ""Demo List"". It will add the list item to the europe folder which is located in the projects folder. Folders will be created if needed.",
         SortOrder = 3)]
-#if !ONPREMISES
     [CmdletExample(
         Code = @"Add-PnPListItem -List ""Demo List"" -Values @{""Title""=""Sales Report""} -Label ""Public""",
         Remarks = @"Adds a new list item to the ""Demo List"". Sets the retention label to ""Public"" if it exists on the site.",
         SortOrder = 4)]
-#endif
     public class AddListItem : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]

--- a/Commands/Lists/SetListItem.cs
+++ b/Commands/Lists/SetListItem.cs
@@ -30,6 +30,10 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         Code = @"Set-PnPListItem -List ""Demo List"" -Identity $item -Values @{""Title"" = ""Test Title""; ""Category""=""Test Category""}",
         Remarks = @"Sets fields value in the list item which has been retrieved by for instance Get-PnPListItem. It sets the content type of the item to ""Company"" and it sets both the Title and Category fields with the specified values. Notice, use the internal names of fields.",
         SortOrder = 3)]
+    [CmdletExample(
+        Code = @"Set-PnPListItem -List ""Demo List"" -Identity 1 -Label ""Public""",
+        Remarks = @"Sets the retention label in the list item with ID 1 in the ""Demo List"".",
+        SortOrder = 4)]
     public class SetListItem : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]
@@ -66,6 +70,9 @@ namespace SharePointPnP.PowerShell.Commands.Lists
 #if !ONPREMISES
         [Parameter(Mandatory = false, HelpMessage = "Update the item without creating a new version.")]
         public SwitchParameter SystemUpdate;
+
+        [Parameter(Mandatory = false, HelpMessage = "The name of the retention label.")]
+        public String Label;
 #endif
 
         protected override void ExecuteCmdlet()
@@ -146,6 +153,31 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                       );
 #endif
                 }
+#if !ONPREMISES
+                if (!String.IsNullOrEmpty(Label))
+                {
+                    IList<Microsoft.SharePoint.Client.CompliancePolicy.ComplianceTag> tags = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetAvailableTagsForSite(ClientContext, ClientContext.Url);
+                    ClientContext.ExecuteQueryRetry();
+
+                    var tag = tags.Where(t => t.TagName == Label).FirstOrDefault();
+
+                    if(tag != null)
+                    {
+                        try
+                        {
+                            item.SetComplianceTag(tag.TagName, tag.BlockDelete, tag.BlockEdit, tag.IsEventTag, tag.SuperLock);
+                            ClientContext.ExecuteQueryRetry();
+                        }
+                        catch (System.Exception error)
+                        {
+                            WriteWarning(error.Message.ToString());
+                        }
+                    } else
+                    {
+                        WriteWarning("Can not find compliance tag with value: " + Label);
+                    }
+                }
+#endif
                 WriteObject(item);
             }
         }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Extended the AddListItem and SetListItem commands to add a parameter to set the Retention Label if it exists on the site.  If the label doesn't exist on the site, the command completes and issues a warning rather than throwing an exception.  For SharePoint Online only.