### PR TITLE
Management API GetUnifiedLog cmdlet

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -616,7 +616,8 @@ Use -PnPO365ManagementShell instead");
                 {
                     Url = aud;
                 }
-                if (Url.ToLower() == "https://graph.microsoft.com")
+                if ((Url.ToLower() == "https://graph.microsoft.com") ||
+                    (Url.ToLower() == "https://manage.office.com"))
                 {
                     connection = ConnectGraphDeviceLogin(AccessToken);
                 }

--- a/Commands/ManagementApi/GetManagementApiAccessToken.cs
+++ b/Commands/ManagementApi/GetManagementApiAccessToken.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Management.Automation;
+using Newtonsoft.Json.Linq;
+using OfficeDevPnP.Core.Utilities;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+
+namespace SharePointPnP.PowerShell.Commands.ManagementApi
+{
+    [Cmdlet(VerbsCommon.Get, "PnPManagementApiAccessToken")]
+    [CmdletHelp("Gets access token for O365 Management API using app credentials",
+        Category = CmdletHelpCategory.ManagementApi,
+        SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+       Code = "PS:> Connect-PnPOnline -AccessToken (Get-PnPManagementApiAccessToken -TenantId $tenantId -ClientId $clientId -ClientSecret $clientSecret)",
+       Remarks = "Retrieves access token for Management API and uses it in PnP connection",
+       SortOrder = 1)]
+    public class GetManagementApiAccessToken : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "The tenant ID to connect to the Management API.")]
+        public string TenantId;
+
+        [Parameter(Mandatory = true, HelpMessage = "The client id of the app which gives you access to the Management API.")]
+        public string ClientId;
+
+        [Parameter(Mandatory = true, HelpMessage = "The client secret of the app which gives you access to the Management API.")]
+        public string ClientSecret;
+
+        protected override void ExecuteCmdlet()
+        {
+            base.ExecuteCmdlet();
+            var resource = "https://manage.office.com";
+            var body = $"grant_type=client_credentials&client_id={ClientId}&client_secret={ClientSecret}&resource={resource}";
+            var response = HttpHelper.MakePostRequestForString($"https://login.microsoftonline.com/{TenantId}/oauth2/token", body, "application/x-www-form-urlencoded");
+            try
+            {
+                var json = JToken.Parse(response);
+                var accessToken = json["access_token"].ToString();
+                WriteObject(accessToken);
+            }
+            catch(Exception e)
+            {
+                WriteError(new ErrorRecord(e, "", ErrorCategory.ProtocolError, null));
+            }
+        }
+    }
+}

--- a/Commands/ManagementApi/GetUnifiedAuditLog.cs
+++ b/Commands/ManagementApi/GetUnifiedAuditLog.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using Newtonsoft.Json;
+using OfficeDevPnP.Core.Framework.Graph;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+using SharePointPnP.PowerShell.Commands.Model;
+
+namespace SharePointPnP.PowerShell.Commands.ManagementApi
+{
+
+    public enum AuditContentType
+    {
+        AzureActiveDirectory,
+        Exchange,
+        SharePoint,
+        General,
+        DLP
+    }
+
+    [Cmdlet(VerbsCommon.Get, "PnPUnifiedAuditLog")]
+    [CmdletHelp(
+        "Gets unified audit logs from O365 Management API",
+        Category = CmdletHelpCategory.ManagementApi,
+        SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+       Code = "PS:> Get-PnPUnifiedAuditLog -ContentType SharePoint  -StartTime ([DateTime]::Today.AddDays(-1)) -EndTime  ([DateTime]::Today.AddDays(-2))",
+       Remarks = "Retrieves access token for Management API and uses it in PnP connection",
+       SortOrder = 1)]
+    public class GetUnifiedAuditLog : PnPGraphCmdlet
+    {
+        private const string ParameterSet_LogsByDate = "Logs by date";
+
+        [Parameter(Mandatory = false, HelpMessage = "Content type of logs to be retreived, should be one of the following: AzureActiveDirectory, Exchange, SharePoint, General, DLP.")]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LogsByDate, HelpMessage = "Content type of logs to be retreived, should be one of the following: AzureActiveDirectory, Exchange, SharePoint, General, DLP.")]
+        public AuditContentType ContentType = AuditContentType.SharePoint;
+
+        [Parameter(
+            Mandatory = false,
+            ParameterSetName = ParameterSet_LogsByDate,
+            HelpMessage = "Start time of logs to be retreived. Start time and end time must both be specified (or both omitted) and must be less than or equal to 24 hours apart, with the start time prior to  end time and start time no more than 7 days in the past.")]
+        public DateTime StartTime = DateTime.MinValue;
+
+        [Parameter(
+            Mandatory = false,
+            ParameterSetName = ParameterSet_LogsByDate,
+            HelpMessage = "End time of logs to be retreived. Start time and end time must both be specified (or both omitted) and must be less than or equal to 24 hours apart.")]
+        public DateTime EndTime = DateTime.MaxValue;
+
+        private string tenantId;
+        protected string TenantId
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(tenantId) && !string.IsNullOrEmpty(AccessToken))
+                {
+                    var jwtToken = new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(AccessToken);
+                    tenantId = jwtToken.Claims.FirstOrDefault(c => c.Type == "tid").Value;
+                }
+                return tenantId;
+            }
+        }
+
+        protected string ContentTypeString
+        {
+            get
+            {
+                string res = null;
+                switch (ContentType)
+                {
+                    case AuditContentType.AzureActiveDirectory:
+                        res = "Audit.AzureActiveDirectory";
+                        break;
+                    case AuditContentType.SharePoint:
+                        res = "Audit.SharePoint";
+                        break;
+                    case AuditContentType.Exchange:
+                        res = "Audit.Exchange";
+                        break;
+                    case AuditContentType.DLP:
+                        res = "DLP.All";
+                        break;
+                    case AuditContentType.General:
+                    default:
+                        res = "Audit.General";
+                        break;
+                }
+                return res;
+            }
+        }
+
+        protected string RootUrl
+        {
+            get
+            {
+                return $"https://manage.office.com/api/v1.0/{TenantId}/activity/feed/";
+            }
+        }
+
+        private IEnumerable<ManagementApiSubscription> GetSubscriptions()
+        {
+            var url = $"{RootUrl}/subscriptions/list";
+            var res = GraphHttpClient.MakeGetRequestForString(url.ToString(), AccessToken);
+            var subscriptions = JsonConvert.DeserializeObject<IEnumerable<ManagementApiSubscription>>(res);
+            return subscriptions;
+        }
+
+        private void EnsureSubscription(string contentType)
+        {
+            var subscriptions = GetSubscriptions();
+            var subscription = subscriptions.FirstOrDefault(s => s.ContentType == contentType);
+            if (subscription == null)
+            {
+                var url = $"{RootUrl}/subscriptions/start?contentType={contentType}&PublisherIdentifier={TenantId}";
+                var res = GraphHttpClient.MakePostRequestForString(url.ToString(), accessToken: AccessToken);
+                var response = JsonConvert.DeserializeObject<ManagementApiSubscription>(res);
+                if (response.Status != "enabled")
+                {
+                    throw new Exception($"Cannot enable subscription for {contentType}");
+                }
+            }
+        }
+
+        protected override void ExecuteCmdlet()
+        {
+            EnsureSubscription(ContentTypeString);
+
+            var url = $"{RootUrl}/subscriptions/content?contentType={ContentTypeString}&PublisherIdentifier=${tenantId}";
+            if (StartTime != DateTime.MinValue)
+            {
+                url += $"&startTime={StartTime.ToString("yyyy-MM-ddThh:mm:ss")}";
+            }
+            if (EndTime != DateTime.MaxValue)
+            {
+                url += $"&endTime={EndTime.ToString("yyyy-MM-ddThh:mm:ss")}";
+            }
+            var res = GraphHttpClient.MakeGetRequestForString(url.ToString(), AccessToken);
+            if (!string.IsNullOrEmpty(res))
+            {
+                var contents = JsonConvert.DeserializeObject<IEnumerable<ManagementApiSubscriptionContent>>(res);
+                foreach (var content in contents)
+                {
+                    res = GraphHttpClient.MakeGetRequestForString(content.ContentUri, AccessToken);
+                    var logs = JsonConvert.DeserializeObject<IEnumerable<ManagementApiUnifiedLogRecord>>(res);
+                    WriteObject(logs, true);
+                }
+            }
+        }
+    }
+}

--- a/Commands/Model/ManagementApiSubscription.cs
+++ b/Commands/Model/ManagementApiSubscription.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SharePointPnP.PowerShell.Commands.Model
+{
+    class ManagementApiSubscription
+    {
+        [JsonProperty("contentType")]
+        public string ContentType { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("webhook")]
+        public JObject Webhook { get; set; }
+    }
+}

--- a/Commands/Model/ManagementApiSubscriptionContent.cs
+++ b/Commands/Model/ManagementApiSubscriptionContent.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SharePointPnP.PowerShell.Commands.Model
+{
+    class ManagementApiSubscriptionContent
+    {
+        [JsonProperty("contentUri")]
+        public string ContentUri { get; set; }
+
+        [JsonProperty("contentId")]
+        public string ContentId { get; set; }
+
+        [JsonProperty("contentType")]
+        public string ContentType { get; set; }
+
+        [JsonProperty("contentCreated")]
+        public DateTime ContentCreated { get; set; }
+
+        [JsonProperty("contentExpiration")]
+        public DateTime ContentExpiration { get; set; }
+    }
+}

--- a/Commands/Model/ManagementApiUnifiedLogRecord.cs
+++ b/Commands/Model/ManagementApiUnifiedLogRecord.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharePointPnP.PowerShell.Commands.Model
+{
+    class ManagementApiUnifiedLogRecord
+    {
+        public DateTime CreationTime { get; set; }
+        public Guid Id { get; set; }
+        public string Operation { get; set; }
+        public Guid OrganizationId { get; set; }
+        public int RecordType { get; set; }
+        public string UserKey { get; set; }
+        public int UserType { get; set; }
+        public int Version { get; set; }
+        public string Workload { get; set; }
+        public string ClientIP { get; set; }
+        public string ObjectId { get; set; }
+        public string UserId { get; set; }
+        public Guid CorrelationId { get; set; }
+        public string EventSource { get; set; }
+        public string ItemType { get; set; }
+        public string UserAgent { get; set; }
+        public string EventData { get; set; }
+    }
+}

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -614,6 +614,11 @@
     <Compile Include="InformationManagement\GetLabel.cs" />
     <Compile Include="InformationManagement\SetLabel.cs" />
     <Compile Include="Lists\ClearDefaultColumnValues.cs" />
+    <Compile Include="ManagementApi\GetManagementApiAccessToken.cs" />
+    <Compile Include="ManagementApi\GetUnifiedAuditLog.cs" />
+    <Compile Include="Model\ManagementApiSubscription.cs" />
+    <Compile Include="Model\ManagementApiSubscriptionContent.cs" />
+    <Compile Include="Model\ManagementApiUnifiedLogRecord.cs" />
     <Compile Include="Model\PnPException.cs" />
     <Compile Include="Model\ProvisionedSite.cs" />
     <Compile Include="Model\ServicePrincipalPermissionGrant.cs" />

--- a/HelpAttributes/CmdletHelpCategory.cs
+++ b/HelpAttributes/CmdletHelpCategory.cs
@@ -53,7 +53,8 @@ namespace SharePointPnP.PowerShell.CmdletHelpAttributes
         [EnumMember(Value = "Diagnostic utilities")]
         Diagnostic = 28,
         [EnumMember(Value = "Site Designs")]
-        SiteDesigns = 29
-            
+        SiteDesigns = 29,
+        [EnumMember(Value = "Management API")]
+        ManagementApi = 30
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
2 new cmdlets to interact with O365 Management rest API.
 * Get-PnPManagementApiAccessToken to retrieve access token for Management API using app credentials, app should be registered in AAD and assigned to interact with Management API
* Get-PnPUnifiedAuditLog to retrieve unified audit logs from Management API (as described here https://docs.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference)

Combining two cmdlets to retrieve audit logs:
```
Connect-PnPOnline -AccessToken (Get-PnPManagementApiAccessToken -TenantId $tenantId -ClientId $clientId -ClientSecret $clientSecret)
$logs = Get-PnPUnifiedAuditLog
```


