### PR TITLE
Feature: Enables Add-PnPClientSideWebPart for SP2019

### DIFF
--- a/Commands/WebParts/AddClientSideWebPart.cs
+++ b/Commands/WebParts/AddClientSideWebPart.cs
@@ -1,4 +1,4 @@
-﻿#if !ONPREMISES
+﻿#if !SP2013 && !SP2016
 using OfficeDevPnP.Core.Pages;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
@@ -10,7 +10,7 @@ namespace SharePointPnP.PowerShell.Commands.WebParts
     [Cmdlet(VerbsCommon.Add, "PnPClientSideWebPart")]
     [CmdletHelp("Adds a Client-Side Web Part to a client-side page",
         "Adds a client-side web part to an existing client-side page.",
-      Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online)]
+      Category = CmdletHelpCategory.ClientSidePages, SupportedPlatform = CmdletSupportedPlatform.Online | CmdletSupportedPlatform.SP2019)]
     [CmdletExample(
         Code = @"PS:> Add-PnPClientSideWebPart -Page ""MyPage"" -DefaultWebPartType BingMap",
         Remarks = "Adds a built-in Client-Side component 'BingMap' to the page called 'MyPage'",


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N\A

## What is in this Pull Request ? ##
As SharePoint Server 2019 supports modern pages, it contains the same basic APIs as SharePoint Online, so this PR enables the Add-PnPClientSideWebPart cmdlet for use on SharePoint Server 2019