### PR TITLE
Fix issues reported by static analysis - Better exception messages

### DIFF
--- a/Commands/ClientSidePages/GetAvailableClientSideComponents.cs
+++ b/Commands/ClientSidePages/GetAvailableClientSideComponents.cs
@@ -32,6 +32,8 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         protected override void ExecuteCmdlet()
         {
             var clientSidePage = Page.GetPage(ClientContext);
+            if (clientSidePage == null)
+                throw new PSArgumentException($"Page '{Page}' does not exist", "List");
 
             if (Component == null)
             {

--- a/Commands/ContentTypes/AddContentTypeToList.cs
+++ b/Commands/ContentTypes/AddContentTypeToList.cs
@@ -27,6 +27,8 @@ namespace SharePointPnP.PowerShell.Commands.ContentTypes
         {
             ContentType ct = null;
             List list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             if (ContentType.ContentType == null)
             {

--- a/Commands/ContentTypes/GetContentType.cs
+++ b/Commands/ContentTypes/GetContentType.cs
@@ -63,6 +63,8 @@ namespace SharePointPnP.PowerShell.Commands.ContentTypes
                 else
                 {
                     List list = List.GetList(SelectedWeb);
+                    if (list == null)
+                        throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
                     ClientContext.ExecuteQueryRetry();
 
@@ -111,6 +113,8 @@ namespace SharePointPnP.PowerShell.Commands.ContentTypes
                 else
                 {
                     List list = List.GetList(SelectedWeb);
+                    if (list == null)
+                        throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
                     var cts = ClientContext.LoadQuery(list.ContentTypes.Include(ct => ct.Id, ct => ct.Name, ct => ct.StringId, ct => ct.Group));
                     ClientContext.ExecuteQueryRetry();
                     WriteObject(cts, true);

--- a/Commands/Diagnostic/MeasurePnPList.cs
+++ b/Commands/Diagnostic/MeasurePnPList.cs
@@ -38,6 +38,8 @@ namespace SharePointPnP.PowerShell.Commands.Diagnostic
         protected override void ExecuteCmdlet()
         {
             var list = Identity.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{Identity}'", "Identity");
             var retrievalExpressions = new Expression<Func<List, object>>[] {
                 l => l.ItemCount,
                 l => l.HasUniqueRoleAssignments,

--- a/Commands/DocumentSets/AddDocumentSet.cs
+++ b/Commands/DocumentSets/AddDocumentSet.cs
@@ -29,6 +29,8 @@ namespace SharePointPnP.PowerShell.Commands.DocumentSets
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
             list.EnsureProperties(l => l.RootFolder, l => l.ContentTypes);
 
             // Try getting the content type from the Web

--- a/Commands/Events/RemoveEventReceiver.cs
+++ b/Commands/Events/RemoveEventReceiver.cs
@@ -47,6 +47,8 @@ namespace SharePointPnP.PowerShell.Commands.Events
             if (ParameterSetName == "List")
             {
                 var list = List.GetList(SelectedWeb);
+                if (list == null)
+                    throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
                 if (MyInvocation.BoundParameters.ContainsKey("Identity"))
                 {

--- a/Commands/Fields/AddField.cs
+++ b/Commands/Fields/AddField.cs
@@ -113,6 +113,8 @@ Remarks = @"This will add a field of type Multiple Choice to the list ""Demo Lis
             if (List != null)
             {
                 var list = List.GetList(SelectedWeb);
+                if (list == null)
+                    throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
                 Field f;
                 if (ParameterSetName != ParameterSet_ADDFIELDREFERENCETOLIST)
                 {

--- a/Commands/InformationManagement/GetListInformationRightsManagement.cs
+++ b/Commands/InformationManagement/GetListInformationRightsManagement.cs
@@ -19,6 +19,8 @@ namespace SharePointPnP.PowerShell.Commands.InformationManagement
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb, l => l.IrmEnabled, l => l.IrmExpire, l => l.IrmReject);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             ClientContext.Load(list.InformationRightsManagementSettings);
             ClientContext.ExecuteQueryRetry();

--- a/Commands/InformationManagement/SetListInformationRightsManagement.cs
+++ b/Commands/InformationManagement/SetListInformationRightsManagement.cs
@@ -74,6 +74,8 @@ namespace SharePointPnP.PowerShell.Commands.InformationManagement
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb, l => l.InformationRightsManagementSettings, l => l.IrmEnabled, l => l.IrmExpire, l => l.IrmReject);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             if (list.IrmEnabled == false && !Enable.HasValue)
             {

--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -76,6 +76,8 @@ namespace SharePointPnP.PowerShell.Commands.Lists
 		protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             if (HasId())
             {

--- a/Commands/Lists/MoveListItemToRecycleBin.cs
+++ b/Commands/Lists/MoveListItemToRecycleBin.cs
@@ -26,6 +26,8 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
             if (Identity != null)
             {
                 var item = Identity.GetListItem(list);

--- a/Commands/Lists/RemoveListItem.cs
+++ b/Commands/Lists/RemoveListItem.cs
@@ -33,6 +33,8 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
             if (Identity != null)
             {
                 var item = Identity.GetListItem(list);

--- a/Commands/RecordsManagement/ClearListItemAsRecord.cs
+++ b/Commands/RecordsManagement/ClearListItemAsRecord.cs
@@ -24,6 +24,8 @@ namespace SharePointPnP.PowerShell.Commands.RecordsManagement
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             var item = Identity.GetListItem(list);
 

--- a/Commands/RecordsManagement/SetListItemAsRecord.cs
+++ b/Commands/RecordsManagement/SetListItemAsRecord.cs
@@ -32,6 +32,8 @@ namespace SharePointPnP.PowerShell.Commands.RecordsManagement
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             var item = Identity.GetListItem(list);
 

--- a/Commands/RecordsManagement/TestListItemIsRecord.cs
+++ b/Commands/RecordsManagement/TestListItemIsRecord.cs
@@ -24,6 +24,8 @@ namespace SharePointPnP.PowerShell.Commands.RecordsManagement
         protected override void ExecuteCmdlet()
         {
             var list = List.GetList(SelectedWeb);
+            if (list == null)
+                throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
             var item = Identity.GetListItem(list);
 

--- a/Commands/Workflows/GetWorkflowSubscription.cs
+++ b/Commands/Workflows/GetWorkflowSubscription.cs
@@ -37,6 +37,8 @@ namespace SharePointPnP.PowerShell.Commands.Workflows
             if (List != null)
             {
                 var list = List.GetList(SelectedWeb);
+                if (list == null)
+                    throw new PSArgumentException($"No list found with id, title or url '{List}'", "List");
 
                 if (string.IsNullOrEmpty(Name))
                 {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
This PR adds some null-checks for List/Page parameters to Cmdlets to show a clear message to the user instead of a generic "Object reference not set to an instance of an object" which is often confusing (what was null ? something I passed as parameter ?)
Most of the affected cases are about ListPipeBind, with only 1 case about ClientSidePagePipeBind .

Output with this PR:
![image](https://user-images.githubusercontent.com/1153754/65952617-80b79480-e442-11e9-9111-b3855f167048.png)

Here's a list of commands that reproduce all the affected cases handled by this PR:
```powershell
Test-PnPListItemIsRecord -List "a" -Identity 4
Clear-PnPListItemAsRecord -List "a" -Identity 4
Set-PnPListItemAsRecord -List "a" -Identity 4
Move-PnPListItemToRecycleBin -List "a" -Identity 4
Get-PnPAvailableClientSideComponents -Page "a.aspx"
Add-PnPContentTypeToList -List "a" -ContentType "Item"
Add-PnPDocumentSet -List "a" -ContentType "b" -Name "c"
Get-PnPContentType -List "a"
Get-PnPContentType -List "a" -Identity "b"
Add-PnPField -List "a" -DisplayName "b" -InternalName "c" -Type "d"
Remove-PnPEventReceiver -List "a" -Identity "b"
Remove-PnPListItem -List "a" -Identity "b"
Get-PnPListItem -List "a"
Get-PnPWorkflowSubscription -List "a"
```

As these changes simply improve the error output but don't actually fix any real bug, I chose to keep them separate from https://github.com/SharePoint/PnP-PowerShell/pull/2281