### PR TITLE
Add parameter `ExtractWebParts` to command `Add-PnPFileToProvisioningTemplate`

### DIFF
--- a/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
@@ -5,12 +5,15 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Utilities;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Net;
 using PnPFileLevel = OfficeDevPnP.Core.Framework.Provisioning.Model.FileLevel;
+using SPFile = Microsoft.SharePoint.Client.File;
 
 namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
 {
@@ -37,10 +40,14 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
         Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceUrl ""Shared%20Documents/ProjectStatus.docs""",
         Remarks = "Adds a file to a PnP Provisioning Template retrieved from the currently connected site. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
         SortOrder = 5)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceUrl ""SitePages/Home.aspx"" -ExtractWebParts",
+        Remarks = "Adds a file to a PnP Provisioning Template retrieved from the currently connected site. If the file is a classic page, also extract its webparts. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
+        SortOrder = 6)]
     public class AddFileToProvisioningTemplate : PnPWebCmdlet
     {
         const string parameterSet_LOCALFILE = "Local File";
-        const string parameterSet_REMOTEFILE = "Remove File";
+        const string parameterSet_REMOTEFILE = "Remote File";
 
         [Parameter(Mandatory = true, Position = 0, HelpMessage = "Filename of the .PNP Open XML site template to read from, optionally including full path.")]
         public string Path;
@@ -63,6 +70,9 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
         [Parameter(Mandatory = false, Position = 5, HelpMessage = "Set to overwrite in site, Defaults to true")]
         public SwitchParameter FileOverwrite = true;
 
+        [Parameter(Mandatory = false, Position = 6, ParameterSetName = parameterSet_REMOTEFILE, HelpMessage = "Include webparts if the file is a page")]
+        public SwitchParameter ExtractWebParts = true;
+
         [Parameter(Mandatory = false, Position = 4, HelpMessage = "Allows you to specify ITemplateProviderExtension to execute while loading the template.")]
         public ITemplateProviderExtension[] TemplateProviderExtensions;
 
@@ -83,7 +93,15 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
             }
             if (this.ParameterSetName == parameterSet_REMOTEFILE)
             {
-                SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+                if (ExtractWebParts)
+                {
+                    ClientContext.Load(SelectedWeb, web => web.Url, web => web.Id, web => web.ServerRelativeUrl);
+                    ClientContext.Load(((ClientContext)SelectedWeb.Context).Site, site => site.Id, site => site.ServerRelativeUrl, site => site.Url);
+                    ClientContext.Load(SelectedWeb.Lists, lists => lists.Include(l => l.Title, l => l.RootFolder.ServerRelativeUrl, l => l.Id));
+                }
+
+                ClientContext.ExecuteQuery();
+                
                 var sourceUri = new Uri(SourceUrl, UriKind.RelativeOrAbsolute);
                 var serverRelativeUrl =
                     sourceUri.IsAbsoluteUri ? sourceUri.AbsolutePath :
@@ -91,11 +109,11 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
                     SelectedWeb.ServerRelativeUrl.TrimEnd('/') + "/" + SourceUrl;
 
                 var file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
-
-                var fileName = file.EnsureProperty(f => f.Name);
+                file.EnsureProperties(f => f.Name, f => f.ServerRelativeUrl);
+                var fileName = file.Name;
                 var folderRelativeUrl = serverRelativeUrl.Substring(0, serverRelativeUrl.Length - fileName.Length - 1);
                 var folderWebRelativeUrl = HttpUtility.UrlKeyValueDecode(folderRelativeUrl.Substring(SelectedWeb.ServerRelativeUrl.TrimEnd('/').Length + 1));
-                if (ClientContext.HasPendingRequest) ClientContext.ExecuteQuery();
+
                 try
                 {
 #if SP2013 || SP2016
@@ -103,11 +121,18 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
 #else
                     var fi = SelectedWeb.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
+
+                    IEnumerable<WebPart> webParts = null;
+                    if (ExtractWebParts)
+                    {
+                        webParts = ExtractSPFileWebParts(file).ToArray();
+                    }
+
                     var fileStream = fi.OpenBinaryStream();
                     ClientContext.ExecuteQueryRetry();
                     using (var ms = fileStream.Value)
                     {
-                        AddFileToTemplate(template, ms, folderWebRelativeUrl, fileName, folderWebRelativeUrl);
+                        AddFileToTemplate(template, ms, folderWebRelativeUrl, fileName, folderWebRelativeUrl, webParts);
                     }
                 }
                 catch (WebException exc)
@@ -134,7 +159,54 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
             }
         }
 
-        private void AddFileToTemplate(ProvisioningTemplate template, Stream fs, string folder, string fileName, string container)
+        private IEnumerable<WebPart> ExtractSPFileWebParts(SPFile file)
+        {
+            if (file == null) throw new ArgumentNullException(nameof(file));
+
+            if (string.Compare(System.IO.Path.GetExtension(file.Name), ".aspx", true) == 0)
+            {
+                foreach (var spwp in SelectedWeb.GetWebParts(file.ServerRelativeUrl))
+                {
+                    spwp.EnsureProperties(wp => wp.WebPart
+#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
+                , wp => wp.ZoneId
+#endif
+                );
+                    yield return new WebPart
+                    {
+                        Contents = Tokenize(SelectedWeb.GetWebPartXml(spwp.Id, file.ServerRelativeUrl)),
+                        Order = (uint)spwp.WebPart.ZoneIndex,
+                        Title = spwp.WebPart.Title,
+#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
+                        Zone = spwp.ZoneId
+#endif
+                    };
+                }
+            }
+        }
+        private string Tokenize(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+
+            foreach (var list in SelectedWeb.Lists)
+            {
+                var webRelativeUrl = list.GetWebRelativeUrl();
+                if (!webRelativeUrl.StartsWith("_catalogs", StringComparison.Ordinal))
+                {
+                    input = input
+                        .ReplaceCaseInsensitive(list.Id.ToString("D"), "{listid:" + list.Title + "}")
+                        .ReplaceCaseInsensitive(webRelativeUrl, "{listurl:" + list.Title + "}");
+                }
+            }
+            return input.ReplaceCaseInsensitive(SelectedWeb.Url, "{site}")
+                .ReplaceCaseInsensitive(SelectedWeb.ServerRelativeUrl, "{site}")
+                .ReplaceCaseInsensitive(SelectedWeb.Id.ToString(), "{siteid}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.ServerRelativeUrl, "{sitecollection}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.Id.ToString(), "{sitecollectionid}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.Url, "{sitecollection}");
+        }
+
+        private void AddFileToTemplate(ProvisioningTemplate template, Stream fs, string folder, string fileName, string container, IEnumerable<WebPart> webParts = null)
         {
             var source = !string.IsNullOrEmpty(container) ? (container + "/" + fileName) : fileName;
 
@@ -159,6 +231,8 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
                 Level = FileLevel,
                 Overwrite = FileOverwrite,
             };
+
+            if (webParts != null) newFile.WebParts.AddRange(webParts);
 
             template.Files.Add(newFile);
 


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##


## What is in this Pull Request ? ##
This PR adds a switch parameter `ExtractWebPart` to the command `Add-PnPFileToProvisioningTemplate`. When set, if the file is a classic page, its webparts are included in the target provisioning template

