### PR TITLE
Feature: add-pnpfiletoprovisioningtemplate support folder sourcing

### DIFF
--- a/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
@@ -167,19 +167,13 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
             {
                 foreach (var spwp in SelectedWeb.GetWebParts(file.ServerRelativeUrl))
                 {
-                    spwp.EnsureProperties(wp => wp.WebPart
-#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
-                , wp => wp.ZoneId
-#endif
-                );
+                    spwp.EnsureProperties(wp => wp.WebPart, wp => wp.ZoneId);
                     yield return new WebPart
                     {
                         Contents = Tokenize(SelectedWeb.GetWebPartXml(spwp.Id, file.ServerRelativeUrl)),
                         Order = (uint)spwp.WebPart.ZoneIndex,
                         Title = spwp.WebPart.Title,
-#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
                         Zone = spwp.ZoneId
-#endif
                     };
                 }
             }

--- a/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
@@ -5,12 +5,15 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Utilities;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Net;
 using PnPFileLevel = OfficeDevPnP.Core.Framework.Provisioning.Model.FileLevel;
+using SPFile = Microsoft.SharePoint.Client.File;
 
 namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
 {
@@ -37,10 +40,14 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
         Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceUrl ""Shared%20Documents/ProjectStatus.docs""",
         Remarks = "Adds a file to a PnP Provisioning Template retrieved from the currently connected site. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
         SortOrder = 5)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceUrl ""SitePages/Home.aspx"" -ExtractWebParts",
+        Remarks = "Adds a file to a PnP Provisioning Template retrieved from the currently connected site. If the file is a classic page, also extract its webparts. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
+        SortOrder = 6)]
     public class AddFileToProvisioningTemplate : PnPWebCmdlet
     {
         const string parameterSet_LOCALFILE = "Local File";
-        const string parameterSet_REMOTEFILE = "Remove File";
+        const string parameterSet_REMOTEFILE = "Remote File";
 
         [Parameter(Mandatory = true, Position = 0, HelpMessage = "Filename of the .PNP Open XML site template to read from, optionally including full path.")]
         public string Path;
@@ -63,6 +70,9 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
         [Parameter(Mandatory = false, Position = 5, HelpMessage = "Set to overwrite in site, Defaults to true")]
         public SwitchParameter FileOverwrite = true;
 
+        [Parameter(Mandatory = false, Position = 6, ParameterSetName = parameterSet_REMOTEFILE, HelpMessage = "Include webparts if the file is a page")]
+        public SwitchParameter ExtractWebParts = true;
+
         [Parameter(Mandatory = false, Position = 4, HelpMessage = "Allows you to specify ITemplateProviderExtension to execute while loading the template.")]
         public ITemplateProviderExtension[] TemplateProviderExtensions;
 
@@ -83,7 +93,15 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
             }
             if (this.ParameterSetName == parameterSet_REMOTEFILE)
             {
-                SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+                if (ExtractWebParts)
+                {
+                    ClientContext.Load(SelectedWeb, web => web.Url, web => web.Id, web => web.ServerRelativeUrl);
+                    ClientContext.Load(((ClientContext)SelectedWeb.Context).Site, site => site.Id, site => site.ServerRelativeUrl, site => site.Url);
+                    ClientContext.Load(SelectedWeb.Lists, lists => lists.Include(l => l.Title, l => l.RootFolder.ServerRelativeUrl, l => l.Id));
+                }
+
+                ClientContext.ExecuteQuery();
+                
                 var sourceUri = new Uri(SourceUrl, UriKind.RelativeOrAbsolute);
                 var serverRelativeUrl =
                     sourceUri.IsAbsoluteUri ? sourceUri.AbsolutePath :
@@ -91,11 +109,11 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
                     SelectedWeb.ServerRelativeUrl.TrimEnd('/') + "/" + SourceUrl;
 
                 var file = SelectedWeb.GetFileByServerRelativeUrl(serverRelativeUrl);
-
-                var fileName = file.EnsureProperty(f => f.Name);
+                file.EnsureProperties(f => f.Name, f => f.ServerRelativeUrl);
+                var fileName = file.Name;
                 var folderRelativeUrl = serverRelativeUrl.Substring(0, serverRelativeUrl.Length - fileName.Length - 1);
                 var folderWebRelativeUrl = HttpUtility.UrlKeyValueDecode(folderRelativeUrl.Substring(SelectedWeb.ServerRelativeUrl.TrimEnd('/').Length + 1));
-                if (ClientContext.HasPendingRequest) ClientContext.ExecuteQuery();
+
                 try
                 {
 #if SP2013 || SP2016
@@ -103,11 +121,18 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
 #else
                     var fi = SelectedWeb.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 #endif
+
+                    IEnumerable<WebPart> webParts = null;
+                    if (ExtractWebParts)
+                    {
+                        webParts = ExtractSPFileWebParts(file).ToArray();
+                    }
+
                     var fileStream = fi.OpenBinaryStream();
                     ClientContext.ExecuteQueryRetry();
                     using (var ms = fileStream.Value)
                     {
-                        AddFileToTemplate(template, ms, folderWebRelativeUrl, fileName, folderWebRelativeUrl);
+                        AddFileToTemplate(template, ms, folderWebRelativeUrl, fileName, folderWebRelativeUrl, webParts);
                     }
                 }
                 catch (WebException exc)
@@ -134,7 +159,54 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
             }
         }
 
-        private void AddFileToTemplate(ProvisioningTemplate template, Stream fs, string folder, string fileName, string container)
+        private IEnumerable<WebPart> ExtractSPFileWebParts(SPFile file)
+        {
+            if (file == null) throw new ArgumentNullException(nameof(file));
+
+            if (string.Compare(System.IO.Path.GetExtension(file.Name), ".aspx", true) == 0)
+            {
+                foreach (var spwp in SelectedWeb.GetWebParts(file.ServerRelativeUrl))
+                {
+                    spwp.EnsureProperties(wp => wp.WebPart
+#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
+                , wp => wp.ZoneId
+#endif
+                );
+                    yield return new WebPart
+                    {
+                        Contents = Tokenize(SelectedWeb.GetWebPartXml(spwp.Id, file.ServerRelativeUrl)),
+                        Order = (uint)spwp.WebPart.ZoneIndex,
+                        Title = spwp.WebPart.Title,
+#if !SP2016 // Missing ZoneId property in SP2016 version of the CSOM Library
+                        Zone = spwp.ZoneId
+#endif
+                    };
+                }
+            }
+        }
+        private string Tokenize(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+
+            foreach (var list in SelectedWeb.Lists)
+            {
+                var webRelativeUrl = list.GetWebRelativeUrl();
+                if (!webRelativeUrl.StartsWith("_catalogs", StringComparison.Ordinal))
+                {
+                    input = input
+                        .ReplaceCaseInsensitive(list.Id.ToString("D"), "{listid:" + list.Title + "}")
+                        .ReplaceCaseInsensitive(webRelativeUrl, "{listurl:" + list.Title + "}");
+                }
+            }
+            return input.ReplaceCaseInsensitive(SelectedWeb.Url, "{site}")
+                .ReplaceCaseInsensitive(SelectedWeb.ServerRelativeUrl, "{site}")
+                .ReplaceCaseInsensitive(SelectedWeb.Id.ToString(), "{siteid}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.ServerRelativeUrl, "{sitecollection}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.Id.ToString(), "{sitecollectionid}")
+                .ReplaceCaseInsensitive(((ClientContext)SelectedWeb.Context).Site.Url, "{sitecollection}");
+        }
+
+        private void AddFileToTemplate(ProvisioningTemplate template, Stream fs, string folder, string fileName, string container, IEnumerable<WebPart> webParts = null)
         {
             var source = !string.IsNullOrEmpty(container) ? (container + "/" + fileName) : fileName;
 
@@ -159,6 +231,8 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
                 Level = FileLevel,
                 Overwrite = FileOverwrite,
             };
+
+            if (webParts != null) newFile.WebParts.AddRange(webParts);
 
             template.Files.Add(newFile);
 

--- a/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
@@ -49,7 +49,7 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
         Remarks = "Adds the content of a remote folder to a PnP Provisioning Template retrieved from the currently connected site. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
         SortOrder = 7)]
     [CmdletExample(
-        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceFolder ""c:\\data\reports"" -Folder ""Shared Documents""",
+        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceFolder ""c:\\data\\reports"" -Folder ""Shared Documents""",
         Remarks = "Adds the content of a local folder to a PnP Provisioning Template retrieved from the currently connected site.",
         SortOrder = 8)]
     public class AddFileToProvisioningTemplate : PnPWebCmdlet

--- a/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/AddFileToProvisioningTemplate.cs
@@ -44,6 +44,14 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning.Site
         Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceUrl ""SitePages/Home.aspx"" -ExtractWebParts",
         Remarks = "Adds a file to a PnP Provisioning Template retrieved from the currently connected site. If the file is a classic page, also extract its webparts. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
         SortOrder = 6)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceFolderUrl ""Shared Documents""",
+        Remarks = "Adds the content of a remote folder to a PnP Provisioning Template retrieved from the currently connected site. The url can be server relative or web relative. If specifying a server relative url has to start with the current site url.",
+        SortOrder = 7)]
+    [CmdletExample(
+        Code = @"PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceFolder ""c:\\data\reports"" -Folder ""Shared Documents""",
+        Remarks = "Adds the content of a local folder to a PnP Provisioning Template retrieved from the currently connected site.",
+        SortOrder = 8)]
     public class AddFileToProvisioningTemplate : PnPWebCmdlet
     {
         private const string parameterSet_LOCALFILE = "Local File";

--- a/Commands/Utilities/StringExtensions.cs
+++ b/Commands/Utilities/StringExtensions.cs
@@ -1,17 +1,116 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Diagnostics;
+using System.Text;
 
 namespace SharePointPnP.PowerShell.Commands.Utilities
 {
+    /// <summary>
+    /// StringExtensions provides useful methods regarding string manipulation
+    /// </summary>
     public static class StringExtensions
     {
-        public static string ReplaceCaseInsensitive(this string input, string search, string replacement)
+        [DebuggerStepThrough]
+        public static string ReplaceCaseInsensitive(this string str, string oldValue, string newValue)
         {
-            return Regex.Replace(
-                input,
-                Regex.Escape(search),
-                replacement.Replace("$", "$$"),
-                RegexOptions.IgnoreCase
-            );
+            return Replace(str, oldValue, newValue, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns a new string in which all occurrences of a specified string in the current instance are replaced with another
+        /// specified string according the type of search to use for the specified string.
+        /// </summary>
+        /// <param name="str">The string performing the replace method.</param>
+        /// <param name="oldValue">The string to be replaced.</param>
+        /// <param name="newValue">The string replace all occurrences of <paramref name="oldValue"/>.
+        /// If value is equal to <c>null</c>, than all occurrences of <paramref name="oldValue"/> will be removed from the <paramref name="str"/>.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
+        /// <returns>A string that is equivalent to the current string except that all instances of <paramref name="oldValue"/> are replaced with <paramref name="newValue"/>.
+        /// If <paramref name="oldValue"/> is not found in the current instance, the method returns the current instance unchanged.</returns>
+        // Credits to https://stackoverflow.com/a/45756981/588868
+        [DebuggerStepThrough]
+        public static string Replace(
+            this string str,
+            string oldValue,
+            string @newValue,
+            StringComparison comparisonType
+            )
+        {
+            // Check inputs.
+            if (str == null)
+            {
+                // Same as original .NET C# string.Replace behavior.
+                throw new ArgumentNullException(nameof(str));
+            }
+            if (str.Length == 0)
+            {
+                // Same as original .NET C# string.Replace behavior.
+                return str;
+            }
+            if (oldValue == null)
+            {
+                // Same as original .NET C# string.Replace behavior.
+                throw new ArgumentNullException(nameof(oldValue));
+            }
+            if (oldValue.Length == 0)
+            {
+                // Same as original .NET C# string.Replace behavior.
+                throw new ArgumentException("String cannot be of zero length.");
+            }
+
+            //if (oldValue.Equals(newValue, comparisonType))
+            //{
+            //This condition has no sense
+            //It will prevent method from replacesing: "Example", "ExAmPlE", "EXAMPLE" to "example"
+            //return str;
+            //}
+
+            // Prepare string builder for storing the processed string.
+            // Note: StringBuilder has a better performance than String by 30-40%.
+            var resultStringBuilder = new StringBuilder(str.Length);
+
+            // Analyze the replacement: replace or remove.
+            var isReplacementNullOrEmpty = string.IsNullOrEmpty(@newValue);
+
+            // Replace all values.
+            const int valueNotFound = -1;
+            int foundAt;
+            var startSearchFromIndex = 0;
+            while ((foundAt = str.IndexOf(oldValue, startSearchFromIndex, comparisonType)) != valueNotFound)
+            {
+                // Append all characters until the found replacement.
+                var @charsUntilReplacment = foundAt - startSearchFromIndex;
+                var isNothingToAppend = @charsUntilReplacment == 0;
+                if (!isNothingToAppend)
+                {
+                    resultStringBuilder.Append(str, startSearchFromIndex, @charsUntilReplacment);
+                }
+
+                // Process the replacement.
+                if (!isReplacementNullOrEmpty)
+                {
+                    resultStringBuilder.Append(@newValue);
+                }
+
+                // Prepare start index for the next search.
+                // This needed to prevent infinite loop, otherwise method always start search
+                // from the start of the string. For example: if an oldValue == "EXAMPLE", newValue == "example"
+                // and comparisonType == "any ignore case" will conquer to replacing:
+                // "EXAMPLE" to "example" to "example" to "example" … infinite loop.
+                startSearchFromIndex = foundAt + oldValue.Length;
+                if (startSearchFromIndex == str.Length)
+                {
+                    // It is end of the input string: no more space for the next search.
+                    // The input string ends with a value that has already been replaced.
+                    // Therefore, the string builder with the result is complete and no further action is required.
+                    return resultStringBuilder.ToString();
+                }
+            }
+
+            // Append the last part to the result.
+            var @charsUntilStringEnd = str.Length - startSearchFromIndex;
+            resultStringBuilder.Append(str, startSearchFromIndex, @charsUntilStringEnd);
+
+            return resultStringBuilder.ToString();
         }
     }
 }


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Requires #2288, replaces #1650

## What is in this Pull Request ? ##
This PR replaces #1650, because it was simpler to start against the latest dev branch. As @erwinvanhunen requested, this PR did not add a new command, but new parameters to the existing one.

It allows to inject the content of a folder in a template. Either from a local folder:

    PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceFolder ""c:\data\reports"" -Folder "Shared Documents"

or from a remote folder : 

    PS:> Add-PnPFileToProvisioningTemplate -Path template.pnp -SourceFolderUrl ""Shared Documents""