### PR TITLE
Disabled TimeZone as mandatory parameter for New-PnPTenantSite

### DIFF
--- a/Commands/Admin/NewTenantSite.cs
+++ b/Commands/Admin/NewTenantSite.cs
@@ -55,7 +55,11 @@ Online site collection fails if a deleted site with the same URL exists in the R
         [Parameter(Mandatory = false, HelpMessage = @"Specifies the site collection template type. Use the Get-PnPWebTemplates cmdlet to get the list of valid templates. If no template is specified, one can be added later. The Template and LocaleId parameters must be a valid combination as returned from the Get-PnPWebTemplates cmdlet.")]
         public string Template = "STS#0";
 
+#if ONPREMISES
+        [Parameter(Mandatory = false, HelpMessage = "Use Get-PnPTimeZoneId to retrieve possible timezone values")]
+#else
         [Parameter(Mandatory = true, HelpMessage = "Use Get-PnPTimeZoneId to retrieve possible timezone values")]
+#endif
         public int TimeZone;
 
         [Parameter(Mandatory = false, HelpMessage = @"Specifies the quota for this site collection in Sandboxed Solutions units. This value must not exceed the company's aggregate available Sandboxed Solutions quota. The default value is 0. For more information, see Resource Usage Limits on Sandboxed Solutions in SharePoint 2010 : http://msdn.microsoft.com/en-us/library/gg615462.aspx.")]


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Made TimeZone an optional parameter for New-PnPTenantSite as OnPrem does not consider that value when creating new sites.