### PR TITLE
Fixed issue when connecting to single level domain URLs

### DIFF
--- a/Commands/Base/PnPAdminCmdlet.cs
+++ b/Commands/Base/PnPAdminCmdlet.cs
@@ -75,7 +75,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
                 {
                     _baseUri =
                        new Uri(
-                           $"{uri.Scheme}://{uriParts[0].ToLower().Replace("-admin", "")}.{string.Join(".", uriParts.Skip(1))}{(!uri.IsDefaultPort ? ":" + uri.Port : "")}");
+                           $"{uri.Scheme}://{uriParts[0].ToLower().Replace("-admin", "")}{(uriParts.Length > 1 ? $".{string.Join(".", uriParts.Skip(1))}" : string.Empty )}{(!uri.IsDefaultPort ? ":" + uri.Port : "")}");
 
                 }
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixed issue when connecting to single level domain (SLD) URLs
BaseUrl in PnPAdminCmdlet would then be **http://sld.** and not **http://sld** as expected (extra dot at the end)
SLD ULRs can exist in on-prem dev environments