### PR TITLE
New-PnPSite doesn't apply site design when using SiteDesignID parameter

### DIFF
--- a/Commands/Admin/NewSite.cs
+++ b/Commands/Admin/NewSite.cs
@@ -130,7 +130,7 @@ namespace SharePointPnP.PowerShell.Commands
                 {
                     creationInformation.HubSiteId = HubSiteId.Id;
                 }
-                if (ParameterSetName == "CommunicationCustomInDesign")
+                if (ParameterSetName == ParameterSet_COMMUNICATIONCUSTOMDESIGN)
                 {
                     creationInformation.SiteDesignId = _communicationSiteParameters.SiteDesignId.Id;
                 }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature

## Related Issues? ##
Partially fixes #2309

## What is in this Pull Request ? ##
In the New-PnPSite the ParameterSetName was checked against a string literal and not the refactored const field, that was renamed. Because of this the SiteDesignId was never set on the creationInformation object when supplying a SiteDesignId when calling New-PnPSite.
