### PR TITLE
Fix: improved detection of Group sites while setting logo

### DIFF
--- a/Commands/Site/SetSite.cs
+++ b/Commands/Site/SetSite.cs
@@ -136,7 +136,6 @@ namespace SharePointPnP.PowerShell.Commands.Site
                 siteUrl = context.Url;
             }
 
-
             if (MyInvocation.BoundParameters.ContainsKey("Classification"))
             {
                 site.Classification = Classification;
@@ -144,8 +143,9 @@ namespace SharePointPnP.PowerShell.Commands.Site
             }
             if (MyInvocation.BoundParameters.ContainsKey("LogoFilePath"))
             {
-                var webTemplate = ClientContext.Web.EnsureProperty(w => w.WebTemplate);
-                if (webTemplate == "GROUP")
+                //var webTemplate = ClientContext.Web.EnsureProperty(w => w.WebTemplate);
+                site.EnsureProperty(s => s.GroupId);
+                if (site.GroupId != Guid.Empty)
                 {
                     if (!System.IO.Path.IsPathRooted(LogoFilePath))
                     {
@@ -171,7 +171,7 @@ namespace SharePointPnP.PowerShell.Commands.Site
                             mimeType = "image/png";
                         }
 #endif
-                        var result = OfficeDevPnP.Core.Sites.SiteCollection.SetGroupImage(context, bytes, mimeType).GetAwaiter().GetResult();
+                        var result = OfficeDevPnP.Core.Sites.SiteCollection.SetGroupImageAsync(context, bytes, mimeType).GetAwaiter().GetResult();
                     }
                     else
                     {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2326

## What is in this Pull Request ? ##
This PR improves the detection of Group sites while setting logo when using `Set-PnPSite` command.
We will use the GroupId property which always has a value whenever it is associated to a Group be it a modern team site or a groupified site.

Also, removed the usage of obsolete `SetGroupImage` method in favour of `SetGroupImageAsync` method,