### PR TITLE
Fix missing parameters in Add-PnPCustomAction command for SP2019

### DIFF
--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -56,6 +56,9 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         public string Location = string.Empty;
 
         [Parameter(Mandatory = false, HelpMessage = "Sequence of this CustomAction being injected. Use when you have a specific sequence with which to have multiple CustomActions being added to the page.", ParameterSetName = ParameterSet_DEFAULT)]
+#if !SP2013 && !SP2016
+        [Parameter(Mandatory = false, HelpMessage = "Optional activation sequence order for the extensions. Used if multiple extensions are activated on a same scope.", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
+#endif
         public int Sequence = 0;
 
         [Parameter(Mandatory = false, HelpMessage = "The URL, URI or ECMAScript (JScript, JavaScript) function associated with the action", ParameterSetName = ParameterSet_DEFAULT)]
@@ -132,6 +135,7 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
                     Name = Name,
                     Title = Title,
                     Location = Location,
+                    Sequence = Sequence,
                     ClientSideComponentId = ClientSideComponentId.Id,
                     ClientSideComponentProperties = ClientSideComponentProperties
                 };

--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -68,7 +68,7 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         public string CommandUIExtension = string.Empty;
 
         [Parameter(Mandatory = false, HelpMessage = "The identifier of the object associated with the custom action.", ParameterSetName = ParameterSet_DEFAULT)]
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         [Parameter(Mandatory = false, HelpMessage = "The identifier of the object associated with the custom action.", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
 #endif
         public string RegistrationId = string.Empty;
@@ -77,13 +77,13 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         public PermissionKind[] Rights;
 
         [Parameter(Mandatory = false, HelpMessage = "Specifies the type of object associated with the custom action", ParameterSetName = ParameterSet_DEFAULT)]
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         [Parameter(Mandatory = false, HelpMessage = "Specifies the type of object associated with the custom action", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
 #endif
         public UserCustomActionRegistrationType RegistrationType;
 
         [Parameter(Mandatory = false, HelpMessage = "The scope of the CustomAction to add to. Either Web or Site; defaults to Web. 'All' is not valid for this command.", ParameterSetName = ParameterSet_DEFAULT)]
-#if !ONPREMISES
+#if !SP2013 && !SP2016
         [Parameter(Mandatory = false, HelpMessage = "The scope of the CustomAction to add to. Either Web or Site; defaults to Web. 'All' is not valid for this command.", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
 #endif
         public CustomActionScope Scope = CustomActionScope.Web;


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Enabled a few parameters for Add-PnPCustomAction command in the "Client Side Component Id" parameter set that was incorrectly disabled for SP2019.
Also enabled Sequence in the same parameter set for both Online and SP2019.