### PR TITLE
Fix Get-PnPAccessToken throwing NullReferenceException

### DIFF
--- a/Commands/Base/PnPGraphCmdlet.cs
+++ b/Commands/Base/PnPGraphCmdlet.cs
@@ -39,7 +39,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
 #endif
                     }
                 }
-                else if (SPOnlineConnection.CurrentConnection.AccessToken != null)
+                else if (SPOnlineConnection.CurrentConnection?.AccessToken != null)
                 {
                     return SPOnlineConnection.CurrentConnection.AccessToken;
                 }

--- a/Commands/Base/TokenHandling.cs
+++ b/Commands/Base/TokenHandling.cs
@@ -9,21 +9,32 @@ namespace SharePointPnP.PowerShell.Commands.Base
     {
         internal static string AcquireToken(string resource, string scope = null)
         {
+            if (SPOnlineConnection.CurrentConnection == null)
+                return null;
+
             var tenantId = TenantExtensions.GetTenantIdByUrl(SPOnlineConnection.CurrentConnection.Url);
 
             if (tenantId == null) return null;
 
-            var clientId = "31359c7f-bd7e-475c-86db-fdb8c937548e";
-            var username = SPOnlineConnection.CurrentConnection.PSCredential.UserName;
-            var password = EncryptionUtility.ToInsecureString(SPOnlineConnection.CurrentConnection.PSCredential.Password);
-            var body = $"grant_type=password&client_id={clientId}&username={username}&password={password}&resource={resource}";
-            var response = HttpHelper.MakePostRequestForString($"https://login.microsoftonline.com/{tenantId}/oauth2/token", body, "application/x-www-form-urlencoded");
-            try
+            // for now only PowerShell credentials are supported
+            if (SPOnlineConnection.CurrentConnection.PSCredential != null)
             {
-                var json = JToken.Parse(response);
-                return json["access_token"].ToString();
+                var clientId = "31359c7f-bd7e-475c-86db-fdb8c937548e";
+                var username = SPOnlineConnection.CurrentConnection.PSCredential.UserName;
+                var password = EncryptionUtility.ToInsecureString(SPOnlineConnection.CurrentConnection.PSCredential.Password);
+                var body = $"grant_type=password&client_id={clientId}&username={username}&password={password}&resource={resource}";
+                var response = HttpHelper.MakePostRequestForString($"https://login.microsoftonline.com/{tenantId}/oauth2/token", body, "application/x-www-form-urlencoded");
+                try
+                {
+                    var json = JToken.Parse(response);
+                    return json["access_token"].ToString();
+                }
+                catch
+                {
+                    return null;
+                }
             }
-            catch
+            else
             {
                 return null;
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Fix Get-PnPAccessToken throwing NullReferenceException in these cases:
- No connection made yet, i.e. as first command in a new PowerShell session
- No PowerShell Credentials available, i.e. after calling Connect-PnPOnline -AppId <appid> -AppSecret <appsecret>

A more clear error message is returned in this case "No Azure AD connection, please connect first with Connect-PnPOnline -Graph, Connect-PnPOnline -Scopes or Connect-PnPOnline -AppId -AppSecret -AADDomain"

Before this PR:
![get-pnpaccesstoken error](https://user-images.githubusercontent.com/1153754/70435006-092b6480-1a86-11ea-8802-b8d2c5e7b144.PNG)

After this PR:
![get-pnpaccesstoken fix](https://user-images.githubusercontent.com/1153754/70435020-0d578200-1a86-11ea-966e-532c2c8560a0.PNG)
