### PR TITLE
Fixing issue matching Delve Blog page with ConvertTo-PnPClientSidePage

### DIFF
--- a/Commands/Base/PipeBinds/PagePipeBind.cs
+++ b/Commands/Base/PipeBinds/PagePipeBind.cs
@@ -139,14 +139,14 @@ namespace SharePointPnP.PowerShell.Commands.Base.PipeBinds
                         {
                             query = new CamlQuery
                             {
-                                ViewXml = string.Format(CAMLQueryForBlogByTitle, this.name)
+                                ViewXml = string.Format(CAMLQueryForBlogByTitle, System.Text.Encodings.Web.HtmlEncoder.Default.Encode(this.name))
                             };
                         }
                         else
                         {
                             query = new CamlQuery
                             {
-                                ViewXml = string.Format(CAMLQueryByExtensionAndName, this.name)
+                                ViewXml = string.Format(CAMLQueryByExtensionAndName, System.Text.Encodings.Web.HtmlEncoder.Default.Encode(this.name))
                             };
                         }
 

--- a/Commands/ClientSidePages/ConvertToClientSidePage.cs
+++ b/Commands/ClientSidePages/ConvertToClientSidePage.cs
@@ -250,7 +250,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
                 }
             }
 
-            if (page == null && !this.Folder.Equals(rootFolder, StringComparison.InvariantCultureIgnoreCase))
+            if (page == null && (Folder == null || !this.Folder.Equals(rootFolder, StringComparison.InvariantCultureIgnoreCase)))
             {
                 throw new Exception($"Page '{Identity?.Name}' does not exist");
             }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
If using:
```powershell
ConvertTo-PnPClientSidePage -Identity "Alex&#39;s Blog Post" -Overwrite -TargetWebUrl "https://contoso.sharepoint.com/sites/AlexBlog" -KeepPageCreationModificationInformation -PostAsNews -SetAuthorInPageHeader -DelveKeepSubTitle -Verbose -DelveBlogPage
```
It would not match any page and throw a nullreferenceexception. Fixed the code so it shows a message that the page could not be found instead. Also fixed that if the page contains specific characters such as & like in "Alex&#39;s Blog Post #1" that it will HTML Encode the name first before feeding it it to the CAML query, otherwise it would never find and return the page.