### PR TITLE
Bugfix Apply-PnPProvisioningTemplate -InputInstance from root

### DIFF
--- a/Commands/Provisioning/Site/ApplyProvisioningTemplate.cs
+++ b/Commands/Provisioning/Site/ApplyProvisioningTemplate.cs
@@ -248,7 +248,7 @@ PS:> Apply-PnPProvisioningTemplate -Path NewTemplate.xml -ExtensibilityHandlers 
                         Path = SessionState.Path.CurrentFileSystemLocation.Path;
                     }
                     var fileInfo = new FileInfo(Path);
-                    fileConnector = new FileSystemConnector(fileInfo.DirectoryName, "");
+                    fileConnector = new FileSystemConnector(System.IO.Path.IsPathRooted(fileInfo.FullName) ? fileInfo.FullName : fileInfo.DirectoryName, "");
                     provisioningTemplate.Connector = fileConnector;
                 }
             }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Resolved issue when executing Apply-PnPProvisioningTemplate -InputInstance from the root of a drive. This would throw a vague connectionString error:

![image](https://user-images.githubusercontent.com/5940670/71912872-9e4d7600-3176-11ea-856b-dd53a8ff17e1.png)

With this fix it will now work:

![image](https://user-images.githubusercontent.com/5940670/71912896-a7d6de00-3176-11ea-9fff-2df6c208d159.png)

Have taken a new empty pnp provisioning template here for the sake of demonstration of the issue. It makes no difference if an actual template is being used. If you execute it from the root using -InputInstance, it will never work.