### PR TITLE
Adding HostProperties support to Add-PnPCustomAction

### DIFF
--- a/Commands/Apps/AddApplicationCustomizer.cs
+++ b/Commands/Apps/AddApplicationCustomizer.cs
@@ -36,14 +36,22 @@ namespace SharePointPnP.PowerShell.Commands.Branding
         [Parameter(Mandatory = false, HelpMessage = "The Client Side Component Properties of the application customizer. Specify values as a json string : \"{Property1 : 'Value1', Property2: 'Value2'}\"")]
         public string ClientSideComponentProperties;
 
+#if !ONPREMISES
+        [Parameter(Mandatory = false, HelpMessage = "The Client Side Host Properties of the application customizer. Specify values as a json string : \"{'preAllocatedApplicationCustomizerTopHeight': '50', 'preAllocatedApplicationCustomizerBottomHeight': '50'}\"")]
+        public string ClientSideHostProperties;
+#endif
+
         protected override void ExecuteCmdlet()
         {
-            CustomActionEntity ca = new CustomActionEntity()
+            CustomActionEntity ca = new CustomActionEntity
             {
                 Title = Title,
                 Location = "ClientSideExtension.ApplicationCustomizer",
                 ClientSideComponentId = ClientSideComponentId.Id,
-                ClientSideComponentProperties = ClientSideComponentProperties
+                ClientSideComponentProperties = ClientSideComponentProperties,
+#if !ONPREMISES
+                ClientSideHostProperties = ClientSideHostProperties
+#endif
             };
 
             switch (Scope)

--- a/Commands/Branding/AddCustomAction.cs
+++ b/Commands/Branding/AddCustomAction.cs
@@ -4,8 +4,6 @@ using OfficeDevPnP.Core.Entities;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Enums;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
-using System;
-using Newtonsoft.Json;
 
 namespace SharePointPnP.PowerShell.Commands.Branding
 {
@@ -94,6 +92,11 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
         [Parameter(Mandatory = false, HelpMessage = "The Client Side Component Properties of the custom action. Specify values as a json string : \"{Property1 : 'Value1', Property2: 'Value2'}\"", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
         public string ClientSideComponentProperties;
 #endif
+#if !ONPREMISES
+        [Parameter(Mandatory = false, HelpMessage = "The Client Side Host Properties of the custom action. Specify values as a json string : \"{'preAllocatedApplicationCustomizerTopHeight': '50', 'preAllocatedApplicationCustomizerBottomHeight': '50'}\"", ParameterSetName = ParameterSet_CLIENTSIDECOMPONENTID)]
+        public string ClientSideHostProperties;
+#endif
+
         protected override void ExecuteCmdlet()
         {
             var permissions = new BasePermissions();
@@ -133,7 +136,10 @@ Add-PnPCustomAction -Name 'GetItemsCount' -Title 'Invoke GetItemsCount Action' -
                     Title = Title,
                     Location = Location,
                     ClientSideComponentId = ClientSideComponentId.Id,
-                    ClientSideComponentProperties = ClientSideComponentProperties
+                    ClientSideComponentProperties = ClientSideComponentProperties,
+#if !ONPREMISES
+                    ClientSideHostProperties = ClientSideHostProperties
+#endif
                 };
 
                 if (MyInvocation.BoundParameters.ContainsKey("RegistrationId"))


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adding HostProperties support to Add-PnPCustomAction using -ClientSideComponentProperties argument. See https://docs.microsoft.com/en-us/sharepoint/dev/spfx/extensions/basics/preallocated-space-placeholders for documentation on what this can be utilized for.

Depends on https://github.com/SharePoint/PnP-Sites-Core/pull/2526 to be merged first in PnP Sites Core.

