### PR TITLE
Fixed canceling connecting using Connect-PnPOnline -Graph would throw NullRef

### DIFF
--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -246,20 +246,19 @@ namespace SharePointPnP.PowerShell.Commands.Base
             {
                 messageCallback(returnData["message"]);
 
-
                 var tokenResult = GetTokenResult(connectionUri, returnData, messageCallback, progressCallback, cancelRequest);
 
                 if (tokenResult != null)
                 {
                     progressCallback("Token received");
                     spoConnection = new SPOnlineConnection(tokenResult, ConnectionMethod.GraphDeviceLogin, ConnectionType.O365, minimalHealthScore, retryCount, retryWait, PnPPSVersionTag, host, disableTelemetry, InitializationType.GraphDeviceLogin);
+                    spoConnection.ConnectionMethod = ConnectionMethod.GraphDeviceLogin;
                 }
                 else
                 {
                     progressCallback("No token received.");
                 }
-            }
-            spoConnection.ConnectionMethod = ConnectionMethod.GraphDeviceLogin;
+            }            
             return spoConnection;
         }
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
When connecting using `Connect-PnPOnline -Graph` and canceling out of the polling for authentication results using CTRL+C, it would throw a NullReference exception. Fixed so that it doesn't throw the exception anymore but instead nicely shows that no token has been received.

![image](https://user-images.githubusercontent.com/5940670/71982084-1d4cb800-3224-11ea-85db-205f03aa0f07.png)
