### PR TITLE
Fixing Connect-PnPOnline -AccessToken no longer working

### DIFF
--- a/Commands/Base/ConnectOnline.cs
+++ b/Commands/Base/ConnectOnline.cs
@@ -650,6 +650,21 @@ Use -PnPO365ManagementShell instead");
             }
             else if (ParameterSetName == ParameterSet_ACCESSTOKEN)
             {
+                // Register assembly redirects
+                AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+                {
+                    // Assembly redirect for NewtonSoft.Json for any requested version of it to the version we're using in the current solution
+                    if (args.Name.Contains("Newtonsoft.Json")) return Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "newtonsoft.json.dll"));
+                    foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        if (assembly.FullName.Equals(args.Name))
+                        {
+                            return assembly;
+                        }
+                    }
+                    return null;
+                };
+
                 var jwtToken = new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(AccessToken);
                 var aud = jwtToken.Audiences.FirstOrDefault();
                 var url = Url;


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Use of `Connect-PnPOnline -AccessToken` no longer works because of the NewtonSoft.Json package upgrade from version 10 to 11 done in this commit in April 2019:

https://github.com/SharePoint/PnP-PowerShell/commit/700013bdeb8d6b0e9569db88b41921f66deea844#diff-6c05e73f37aa7d4c0e28014e8985d8c7

The assembly `System.IdentityModel.Tokens.Jwt, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35` being used in PnP PowerShell and specifically used when running `-AccessToken` is being used to parse the base64 encoded JWT token:

`var jwtToken = new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(AccessToken);`

This package however has a requirement for NewtonSoft.Json version 10.x. Since we upgraded to version 11.x, it can't find the assembly anymore and crashes. Assembly redirects from the app.config file are not taken into account for PowerShell as can be seen from the Fusion log. Downgrading back to v10.x is not an option as PnP Sites Core also upgraded to v11.x. Only way I've found to make it work without modifying system wide config files is to register the assembly redirect through code:

```C#               
// Register assembly redirects
AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
{
    // Assembly redirect for NewtonSoft.Json for any requested version of it to the version we're using in the current solution
    if (args.Name.Contains("Newtonsoft.Json")) return Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "newtonsoft.json.dll"));
    foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
    {
        if (assembly.FullName.Equals(args.Name))
        {
            return assembly;
        }
    }
    return null;
};
```

In this PR I've added it to ConnectOnline.cs directly above `var jwtToken = new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(AccessToken);`, but there must be a nicer place to put this where it will always be parsed when running any command inside this PnP PowerShell module.

@erwinvanhunen, would like to discuss what the best location for this would be with you.