### PR TITLE
Pipe out the Folder created by Add-PnPFolder

### DIFF
--- a/Commands/Files/AddFolder.cs
+++ b/Commands/Files/AddFolder.cs
@@ -28,7 +28,9 @@ namespace SharePointPnP.PowerShell.Commands.Files
             ClientContext.Load(folder, f => f.ServerRelativeUrl);
             ClientContext.ExecuteQueryRetry();
 
-            folder.CreateFolder(Name);
+            var result = folder.CreateFolder(Name);
+
+            WriteObject(result);
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1892

## What is in this Pull Request ? ##
This PR pipes out the Microsoft.SharePoint.Client.Folder object created by Add-PnPFolder command, allowing usage like
```powershell
$folder = Add-PnPFolder ...
```