### PR TITLE
Pipe out the List created by New-PnPList

### DIFF
--- a/Commands/Lists/NewList.cs
+++ b/Commands/Lists/NewList.cs
@@ -60,6 +60,8 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                 list.Update();
                 ClientContext.ExecuteQueryRetry();
             }
+
+            WriteObject(list);
         }
     }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
This PR pipes out the List object created by New-PnPList command, allowing usage like
```powershell
$list = New-PnPList ...
```