### PR TITLE
Fix examples in Start-PnPWorkflowInstance

### DIFF
--- a/Commands/Workflows/StartWorkflowInstance.cs
+++ b/Commands/Workflows/StartWorkflowInstance.cs
@@ -14,11 +14,11 @@ namespace SharePointPnP.PowerShell.Commands.Workflows
     [CmdletHelp("Starts a workflow instance on a list item",
         Category = CmdletHelpCategory.Workflows)]
     [CmdletExample(
-        Code = @"PS:> Start-PnPWorkflowInstance -Name 'WorkflowName' -ListItem $item ", 
+        Code = @"PS:> Start-PnPWorkflowInstance -Subscription $subscription -ListItem $item ", 
         Remarks = "Starts a workflow instance on the specified list item",
         SortOrder = 1)]
     [CmdletExample(
-        Code = @"PS:> Start-PnPWorkflowInstance -Name 'WorkflowName' -ListItem 2 ",
+        Code = @"PS:> Start-PnPWorkflowInstance -Subscription $subscription -ListItem 2 ",
         Remarks = "Starts a workflow instance on the specified list item",
         SortOrder = 2)]
     public class StartWorkflowInstance : PnPWebCmdlet


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2482

## What is in this Pull Request ? ##
Updates the examples in Start-PnPWorkflowInstance with the correct syntax.

By inspecting the way WorkflowSubscriptionPipeBind works it doesn't seem to support the Workflow name as parameter so I changed it to a generic $subscription variable.