### PR TITLE
Added Clear-PnPTenantAppCatalogUrl and Set-PnPTenantAppCatalogUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Get-PnPSiteScriptFromList` and `Get-PnPSiteScriptFromWeb` commands which allow generation of Site Script JSON based off of existing lists or an entire site [PR # 2459](https://github.com/SharePoint/PnP-PowerShell/pull/2459)
 - Added `-Aggregations` argument to `Add-PnPView` and `Set-PnPView` to allow for creating a Totals count in a view [PR #2257](https://github.com/SharePoint/PnP-PowerShell/pull/2257)
 - Deprecated old tenant level `Enable-PnPCommSite` cmdlet and added new `Enable-PnPCommSite` command to enable the modern communication site experience on an classic team site. This one can be applied by non tenant admins as well
-- Added `Clear-PnPTenantAppCatalogUrl` to remove the tenant configuration for the tenant scoped app catalog
-- Added `Set-PnPTenantAppCatalogUrl` to configure the tenant for the site collection to use for the tenant scoped app catalog
+- Added `Clear-PnPTenantAppCatalogUrl` to remove the tenant configuration for the tenant scoped app catalog [PR # 2485](https://github.com/SharePoint/PnP-PowerShell/pull/2485)
+- Added `Set-PnPTenantAppCatalogUrl` to configure the tenant for the site collection to use for the tenant scoped app catalog [PR # 2485](https://github.com/SharePoint/PnP-PowerShell/pull/2485)
 
 ### Changed
 - Optimized Invoke-PnPSearchQuery when using the -All parameter to ensure all results are returned by ordering on IndexDocId, and changed the default ClientType to 'PnP'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Get-PnPSiteScriptFromList` and `Get-PnPSiteScriptFromWeb` commands which allow generation of Site Script JSON based off of existing lists or an entire site [PR # 2459](https://github.com/SharePoint/PnP-PowerShell/pull/2459)
 - Added `-Aggregations` argument to `Add-PnPView` and `Set-PnPView` to allow for creating a Totals count in a view [PR #2257](https://github.com/SharePoint/PnP-PowerShell/pull/2257)
 - Deprecated old tenant level `Enable-PnPCommSite` cmdlet and added new `Enable-PnPCommSite` command to enable the modern communication site experience on an classic team site. This one can be applied by non tenant admins as well
+- Added `Clear-PnPTenantAppCatalogUrl` to remove the tenant configuration for the tenant scoped app catalog
+- Added `Set-PnPTenantAppCatalogUrl` to configure the tenant for the site collection to use for the tenant scoped app catalog
 
 ### Changed
 - Optimized Invoke-PnPSearchQuery when using the -All parameter to ensure all results are returned by ordering on IndexDocId, and changed the default ClientType to 'PnP'

--- a/Commands/Admin/ClearTenantAppCatalogUrl.cs
+++ b/Commands/Admin/ClearTenantAppCatalogUrl.cs
@@ -1,0 +1,26 @@
+﻿#if !ONPREMISES
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+
+namespace SharePointPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Clear, "PnPTenantAppCatalogUrl", SupportsShouldProcess = true)]
+    [CmdletHelp(@"Removes the url of the tenant scoped app catalog. It will not delete the site collection itself.",
+        Category = CmdletHelpCategory.TenantAdmin,
+        SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+        Code = @"PS:> Clear-PnPTenantAppCatalogUrl",
+        Remarks = @"Removes the url of the tenant scoped app catalog", SortOrder = 1)]
+    public class ClearTenantAppCatalogUrl : PnPAdminCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            var settings = TenantSettings.GetCurrent(ClientContext);
+            settings.ClearCorporateCatalog();
+            ClientContext.ExecuteQueryRetry();
+        }
+    }
+}
+#endif

--- a/Commands/Admin/GetTenantAppCatalogUrl.cs
+++ b/Commands/Admin/GetTenantAppCatalogUrl.cs
@@ -1,27 +1,22 @@
 ﻿#if !ONPREMISES
-using System.Linq;
 using System.Management.Automation;
-using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
-using SharePointPnP.PowerShell.Commands.Base;
-using SharePointPnP.PowerShell.Commands.Enums;
-using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace SharePointPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "PnPTenantAppCatalogUrl", SupportsShouldProcess = true)]
-    [CmdletHelp(@"Retrieves the url of the tenant scoped app catalog.",
+    [CmdletHelp(@"Retrieves the url of the tenant scoped app catalog",
         Category = CmdletHelpCategory.TenantAdmin,
         SupportedPlatform = CmdletSupportedPlatform.Online)]
-    [CmdletExample(Code = @"PS:> Get-PnPTenantAppCatalogUrl", Remarks = "Returns the url of the tenant scoped app catalog site collection", SortOrder = 1)]
+    [CmdletExample(
+        Code = @"PS:> Get-PnPTenantAppCatalogUrl", 
+        Remarks = "Returns the url of the tenant scoped app catalog site collection", SortOrder = 1)]
     public class GetTenantAppCatalogUrl : PnPCmdlet
     {
         protected override void ExecuteCmdlet()
         {
-            var settings = Microsoft.SharePoint.Client.TenantSettings.GetCurrent(ClientContext);
+            var settings = TenantSettings.GetCurrent(ClientContext);
             settings.EnsureProperties(s => s.CorporateCatalogUrl);
             WriteObject(settings.CorporateCatalogUrl);
         }

--- a/Commands/Admin/SetTenantAppCatalogUrl.cs
+++ b/Commands/Admin/SetTenantAppCatalogUrl.cs
@@ -1,0 +1,29 @@
+﻿#if !ONPREMISES
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands.Base;
+
+namespace SharePointPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Set, "PnPTenantAppCatalogUrl", SupportsShouldProcess = true)]
+    [CmdletHelp(@"Sets the url of the tenant scoped app catalog",
+        Category = CmdletHelpCategory.TenantAdmin,
+        SupportedPlatform = CmdletSupportedPlatform.Online)]
+    [CmdletExample(
+        Code = @"PS:> Set-PnPTenantAppCatalogUrl -Url https://yourtenant.sharepoint.com/sites/appcatalog",
+        Remarks = @"Sets the tenant scoped app catalog to the provided site collection url", SortOrder = 1)]
+    public class SetTenantAppCatalogUrl : PnPAdminCmdlet
+    {
+        [Parameter(Mandatory = true, HelpMessage = "The url of the site to set as the tenant scoped app catalog")]
+        public string Url;
+
+        protected override void ExecuteCmdlet()
+        {
+            var settings = TenantSettings.GetCurrent(ClientContext);
+            settings.SetCorporateCatalog(Url);
+            ClientContext.ExecuteQueryRetry();
+        }
+    }
+}
+#endif

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -560,6 +560,8 @@
     <Compile Include="Admin\AddOrgAssetsLibrary.cs" />
     <Compile Include="Admin\AddSiteCollectionAppCatalog.cs" />
     <Compile Include="Admin\AddTenantTheme.cs" />
+    <Compile Include="Admin\ClearTenantAppCatalogUrl.cs" />
+    <Compile Include="Admin\SetTenantAppCatalogUrl.cs" />
     <Compile Include="Admin\RemoveOrgAssetsLibrary.cs" />
     <Compile Include="Admin\GetHomeSite.cs" />
     <Compile Include="Admin\GetHubSiteChild.cs" />


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added new commands `Clear-PnPTenantAppCatalogUrl` and `Set-PnPTenantAppCatalogUrl` introduced with [the January 2020 CSOM release](https://developer.microsoft.com/en-us/sharepoint/blogs/new-sharepoint-csom-version-released-for-sharepoint-online-january-2020/).

Not all SPO WFEs have been updated yet to support these new CSOM commands, so for the time being it may still throw an exception that the commands are unknown. Should be solved automatically once the servers are updated.