### PR TITLE
Fix Newtonsoft.Json.dll loading in Azure Function v1.0 runtime.

### DIFF
--- a/Commands/Base/BasePSCmdlet.cs
+++ b/Commands/Base/BasePSCmdlet.cs
@@ -7,7 +7,6 @@ namespace SharePointPnP.PowerShell.Commands.Base
 {
     public class BasePSCmdlet : PSCmdlet
     {
-        private Assembly newtonsoftAssembly;
 
         protected override void BeginProcessing()
         {
@@ -23,26 +22,11 @@ namespace SharePointPnP.PowerShell.Commands.Base
 
         private void FixAssemblyResolving()
         {
-            newtonsoftAssembly = Assembly.LoadFrom(Path.Combine(AssemblyDirectory, "NewtonSoft.Json.dll"));
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
-        }
-
-        private string AssemblyDirectory
-        {
-            get
-            {
-                var location = Assembly.GetExecutingAssembly().Location;
-                var escapedLocation = Uri.UnescapeDataString(location);
-                return Path.GetDirectoryName(escapedLocation);
-            }
         }
 
         private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
-            if (args.Name.StartsWith("Newtonsoft.Json"))
-            {
-                return newtonsoftAssembly;
-            }
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (assembly.FullName == args.Name)


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2521 

## What is in this Pull Request ? ##
The change removes the special handling of the "Newtonsoft.Json.dll" as the dll is automatically loaded when importing the module. 

Question: Why was this handled specially in the first place? May this change be breaking the module functionality in a special environment?

