### PR TITLE
Update UninstallSolution.cs

### DIFF
--- a/Commands/Site/UninstallSolution.cs
+++ b/Commands/Site/UninstallSolution.cs
@@ -9,7 +9,7 @@ namespace SharePointPnP.PowerShell.Commands.Site
     [CmdletHelp("Uninstalls a sandboxed solution from a site collection",
         Category = CmdletHelpCategory.Sites)]
     [CmdletExample(
-        Code = @"PS:> Uninstall-PnPSolution -PackageId c2f5b025-7c42-4d3a-b579-41da3b8e7254 -SourceFilePath mypackage.wsp",
+        Code = @"PS:> Uninstall-PnPSolution -PackageId c2f5b025-7c42-4d3a-b579-41da3b8e7254 -PackageName mypackage.wsp",
         Remarks = "Removes the package to the current site",
         SortOrder = 1)]
     public class UninstallSolution : PnPCmdlet


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Sample Fix



## What is in this Pull Request ? ##
This PR fixes an issue when users execute this sample cmdlet of "Uninstall-PnPSolution" will receive  "NamedParameterNotFound" Error. Corrected a parameters of Uninstall-PnPSolution sample cmdlet
