### PR TITLE
Added RemoveEmptySectionsAndColumns option with default true (accorin…

### DIFF
--- a/Commands/ClientSidePages/ConvertToClientSidePage.cs
+++ b/Commands/ClientSidePages/ConvertToClientSidePage.cs
@@ -193,6 +193,9 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
         [Parameter(Mandatory = false, HelpMessage = "When setting a target page folder then the target page folder overrides possibly default folder path (e.g. in the source page lived in a folder) instead of being appended to it")]
         public SwitchParameter TargetPageFolderOverridesDefaultFolder = false;
 
+        [Parameter(Mandatory = false, HelpMessage = "Remove empty sections and columns after transformation of the page")]
+        public SwitchParameter RemoveEmptySectionsAndColumns = true;
+
         [Parameter(Mandatory = false, HelpMessage = "Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.")] // do not remove '#!#99'
         public SPOnlineConnection TargetConnection = null;
 
@@ -443,6 +446,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
                     LDAPConnectionString = this.LDAPConnectionString,
                     TargetPageFolder = this.TargetPageFolder,
                     TargetPageFolderOverridesDefaultFolder = this.TargetPageFolderOverridesDefaultFolder,
+                    RemoveEmptySectionsAndColumns = this.RemoveEmptySectionsAndColumns,
                 };
 
                 // Set mapping properties
@@ -484,6 +488,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
                     LDAPConnectionString = this.LDAPConnectionString,
                     TargetPageFolder = this.TargetPageFolder,
                     TargetPageFolderOverridesDefaultFolder = this.TargetPageFolderOverridesDefaultFolder,
+                    RemoveEmptySectionsAndColumns = this.RemoveEmptySectionsAndColumns
                 };
 
                 // Set mapping properties
@@ -543,6 +548,7 @@ namespace SharePointPnP.PowerShell.Commands.ClientSidePages
                     {
                         AddPageAcceptBanner = this.AddPageAcceptBanner
                     },
+                    RemoveEmptySectionsAndColumns = this.RemoveEmptySectionsAndColumns,
                 };
 
                 // Set mapping properties


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
ConvertTo-PnPClientSidePage will always remove empty sections and columns after the conversion. There is no way to turn it off. Sometimes you don't want the empty sections to be deleted, for instance if you want to add additional webparts after a conversion. Therefore I introduced a switch parameter in order to be able to turn it off. It is true by default to stay in line with the current functionality, so for existing scripts, nothing changes
