### PR TITLE
Changed the execution context to tenant context and added query code …

### DIFF
--- a/Commands/SiteDesigns/GetSiteDesignTask.cs
+++ b/Commands/SiteDesigns/GetSiteDesignTask.cs
@@ -27,7 +27,7 @@ namespace SharePointPnP.PowerShell.Commands.SiteDesigns
        SortOrder = 3)]
     public class GetSiteDesignTask : PnPWebCmdlet
     {
-        [Parameter(Mandatory = false, HelpMessage = "The ID of the site design to apply.")]
+        [Parameter(Mandatory = false, HelpMessage = "The ID of the site design task to retrieve.")]
         public TenantSiteDesignTaskPipeBind Identity;
 
         [Parameter(Mandatory = false, HelpMessage = "The URL of the site collection where the site design will be applied. If not specified the design will be applied to the site you connected to with Connect-PnPOnline.")]
@@ -42,8 +42,8 @@ namespace SharePointPnP.PowerShell.Commands.SiteDesigns
                 if (Identity != null)
                 {
                     var task = Tenant.GetSiteDesignTask(tenantContext, Identity.Id);
-                    ClientContext.Load(task);
-                    ClientContext.ExecuteQueryRetry();
+                    tenantContext.Load(task);
+                    tenantContext.ExecuteQueryRetry();
                     WriteObject(task);
                 }
                 else
@@ -63,6 +63,8 @@ namespace SharePointPnP.PowerShell.Commands.SiteDesigns
                         }
                     }
                     var tasks = tenant.GetSiteDesignTasks(webUrl);
+                    tenantContext.Load( tasks );
+                    tenantContext.ExecuteQueryRetry();
                     WriteObject(tasks, true);
                 }
             }


### PR DESCRIPTION
…to the call without identity parameters.


## Type ##
- [ x ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2543 by using the correct (tenant) execution context.

## What is in this Pull Request ? ##
Changed the lines referencing the client context when actually the tenant context was necessary to retrieve the objects. Also added code for executing the query when the cmdlet is called without parameters.
Also changed the parameter description for Identity because it seems to have been copy/pasted from somewhere else and had been referring to the SiteDesignId when it actually should have referred to the Task Id.
