### PR TITLE
Add FolderServerRelativeUrl optional parameter to Get-PnPListItem to return items from a particular folder

### DIFF
--- a/Commands/Lists/GetListItem.cs
+++ b/Commands/Lists/GetListItem.cs
@@ -60,6 +60,11 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         [Parameter(Mandatory = false, HelpMessage = "The CAML query to execute against the list", ParameterSetName = ParameterSet_BYQUERY)]
         public string Query;
 
+
+        [Parameter(Mandatory = false, HelpMessage = "The server relative URL of a list folder from which results will be returned.", ParameterSetName = ParameterSet_BYQUERY)]
+        [Parameter(Mandatory = false, HelpMessage = "The server relative URL of a list folder from which results will be returned.", ParameterSetName = ParameterSet_ALLITEMS)]
+        public string FolderServerRelativeUrl;
+
         [Parameter(Mandatory = false, HelpMessage = "The fields to retrieve. If not specified all fields will be loaded in the returned list object.", ParameterSetName = ParameterSet_ALLITEMS)]
         [Parameter(Mandatory = false, HelpMessage = "The fields to retrieve. If not specified all fields will be loaded in the returned list object.", ParameterSetName = ParameterSet_BYID)]
         [Parameter(Mandatory = false, HelpMessage = "The fields to retrieve. If not specified all fields will be loaded in the returned list object.", ParameterSetName = ParameterSet_BYUNIQUEID)]
@@ -118,6 +123,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
             else
             {
 				CamlQuery query = HasCamlQuery() ? new CamlQuery { ViewXml = Query } : CamlQuery.CreateAllItemsQuery();
+                query.FolderServerRelativeUrl = FolderServerRelativeUrl;
 
 				if (Fields != null)
                 {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
This PR adds a new optional parameter FolderServerRelativeUrl to Get-PnPListItem to return items from a particular folder.
The parameter can be set when passing only the -List or when specifying a custom query with -Query.

Some examples:
```powershell
"Query recursive without folder set"
Get-PnPListItem -List RecursiveQuery -Query "<View Scope='RecursiveAll'><Query></Query><RowLimit>5000</RowLimit></View>"

"Query recursive WITH folder set"
Get-PnPListItem -List RecursiveQuery -Query "<View Scope='RecursiveAll'><Query></Query><RowLimit>5000</RowLimit></View>" -FolderServerRelativeUrl "/sites/PnPPlayground/RecursiveQuery/Folder 1"

"Query NOT recursive without folder set"
Get-PnPListItem -List RecursiveQuery -Query "<View><Query></Query><RowLimit>5000</RowLimit></View>"

"Query NOT recursive WITH folder set"
Get-PnPListItem -List RecursiveQuery -Query "<View><Query></Query><RowLimit>5000</RowLimit></View>" -FolderServerRelativeUrl "/sites/PnPPlayground/RecursiveQuery/Folder 1"

"All items without folder set"
Get-PnPListItem -List RecursiveQuery

"All items WITH folder set"
Get-PnPListItem -List RecursiveQuery -FolderServerRelativeUrl "/sites/PnPPlayground/RecursiveQuery/Folder 1"

```
