### PR TITLE
missing parameter -AsFileObject

### DIFF
--- a/Commands/Files/GetFile.cs
+++ b/Commands/Files/GetFile.cs
@@ -72,6 +72,9 @@ namespace SharePointPnP.PowerShell.Commands.Files
 
         [Parameter(Mandatory = false, ParameterSetName = URLTOPATH, HelpMessage = "Overwrites the file if it exists.")]
         public SwitchParameter Force;
+        
+        [Parameter(Mandatory = false, ParameterSetName = URLASFILEOBJECT, HelpMessage = "Retrieve the file contents as a file object.")]
+        public SwitchParameter AsFileObject;
 
         protected override void ExecuteCmdlet()
         {


### PR DESCRIPTION
Line 117 runs the case for retrieving a file as an object "case URLASFILEOBJECT" but it cannot be executed because there is no parameter for it.

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/SharePoint/PnP-PowerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Add -AsFileObject parameter

## What is in this Pull Request ? ##
As described above
