### PR TITLE
Fixing newtonsoft assembly resolving not working in Azure Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Marked the -Rights parameter as obsolete on Grant-PnPHubSiteRights. Use Revoke-PnPHubSiteRights to revoke rights for specific users to join sites ot the hubsite
 - Output just the URL for the Redirect url in Get-PnPSearchSettings. Return web setting on sc root as fallback if sc setting is missing (via core).
+- The February 2020 release of PnP PowerShell was throwing an error on not being able to find and load the Newtonsoft assembly when used in an Azure Function. Fixed in this release.
 
 ### Contributors
 
 - Arun Kumar Perumal [arunkumarperumal]
 - Paul Bullock [pkbullock]
+- Koen Zomers [koenzomers]
 
 ## [3.18.2002.0]
 

--- a/Commands/Base/BasePSCmdlet.cs
+++ b/Commands/Base/BasePSCmdlet.cs
@@ -26,10 +26,12 @@ namespace SharePointPnP.PowerShell.Commands.Base
             var newtonsoftAssemblyByLocation = Path.Combine(AssemblyDirectoryFromLocation, "Newtonsoft.Json.dll");
             if (File.Exists(newtonsoftAssemblyByLocation))
             {
+                // Local run, network run, etc.
                 newtonsoftAssembly = Assembly.LoadFrom(newtonsoftAssemblyByLocation);
             }
             else
             {
+                // Running from Azure Function
                 var newtonsoftAssemblyByCodeBase = Path.Combine(AssemblyDirectoryFromCodeBase, "Newtonsoft.Json.dll");
                 newtonsoftAssembly = Assembly.LoadFrom(newtonsoftAssemblyByCodeBase);
             }

--- a/Commands/Base/BasePSCmdlet.cs
+++ b/Commands/Base/BasePSCmdlet.cs
@@ -23,17 +23,37 @@ namespace SharePointPnP.PowerShell.Commands.Base
 
         private void FixAssemblyResolving()
         {
-            newtonsoftAssembly = Assembly.LoadFrom(Path.Combine(AssemblyDirectory, "NewtonSoft.Json.dll"));
+            var newtonsoftAssemblyByLocation = Path.Combine(AssemblyDirectoryFromLocation, "Newtonsoft.Json.dll");
+            if (File.Exists(newtonsoftAssemblyByLocation))
+            {
+                newtonsoftAssembly = Assembly.LoadFrom(newtonsoftAssemblyByLocation);
+            }
+            else
+            {
+                var newtonsoftAssemblyByCodeBase = Path.Combine(AssemblyDirectoryFromCodeBase, "Newtonsoft.Json.dll");
+                newtonsoftAssembly = Assembly.LoadFrom(newtonsoftAssemblyByCodeBase);
+            }
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
         }
 
-        private string AssemblyDirectory
+        private string AssemblyDirectoryFromLocation
         {
             get
             {
                 var location = Assembly.GetExecutingAssembly().Location;
                 var escapedLocation = Uri.UnescapeDataString(location);
                 return Path.GetDirectoryName(escapedLocation);
+            }
+        }
+
+        private string AssemblyDirectoryFromCodeBase
+        {
+            get
+            {
+                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+                UriBuilder uri = new UriBuilder(codeBase);
+                string path = Uri.UnescapeDataString(uri.Path);
+                return Path.GetDirectoryName(path);
             }
         }
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Reported in several issues, such as issue #2123

## What is in this Pull Request ? ##
Fixing newtonsoft assembly resolving not working in Azure Functions. Tried all kinds of approaches, but no single approach I could find would work for when it would be locally installed on a machine, when it would be imported through import-module from a network share and in an Azure Function. Therefore added a simple File.Exists check if it the newtonsoft DLL can be found through its assembly location reference. If so (everything but an Azure Function), load it from there. If not (Azure Function), load it from the CodeBase path as it was being done before. Tested on all three scenarios and its working fine now.