### PR TITLE
Add Windows Auth Request Header for CurrentCredentials

### DIFF
--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -675,6 +675,19 @@ namespace SharePointPnP.PowerShell.Commands.Base
                     // as using "UseDefaultCredentials" in a HttpClient.
                     context.Credentials = CredentialCache.DefaultNetworkCredentials;
                 }
+                
+                //Add Request Header to force Windows Authentication
+                context.ExecutingWebRequest += delegate(object sender, WebRequestEventArgs e)
+                {
+                    try
+                    {
+                        //Add the header that tells SharePoint to use Windows authentication
+                        e.WebRequestExecutor.RequestHeaders.Add(
+                        "X-FORMS_BASED_AUTH_ACCEPTED", "f");
+                    }
+                    catch { }
+                };
+                
             }
 #if SP2013 || SP2016 || SP2019
             var connectionType = ConnectionType.OnPrem;


### PR DESCRIPTION
Add a delegate to inject the "X-FORMS_BASED_AUTH_ACCEPTED" request header into the context to allow for successful windows authentication even when more than one authentication provider is active on the target webapplication

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2570 

## What is in this Pull Request ? ##
When using -CurrentCredentials with Connect-PnPOnline, the Request Header "X-FORMS_BASED_AUTH_ACCEPTED" is injected into every Web Request to allow for Windows Authentication when more than one Authentication Provider is active on the OnPremises Web Application.