### PR TITLE
Fixed compiler warnings

### DIFF
--- a/Commands/Base/NewAzureCertificate.cs
+++ b/Commands/Base/NewAzureCertificate.cs
@@ -85,9 +85,11 @@ PrivateKey contains the PEM encoded private key of the certificate.",
             byte[] certificateBytes = CertificateHelper.CreateSelfSignCertificatePfx(x500, validFrom, validTo, CertificatePassword);
             var certificate = new X509Certificate2(certificateBytes, CertificatePassword, X509KeyStorageFlags.Exportable);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!string.IsNullOrWhiteSpace(Out))
             {
                 OutPfx = Out;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             if (!string.IsNullOrWhiteSpace(OutPfx))
             {

--- a/Commands/Base/SPOnlineConnectionHelper.cs
+++ b/Commands/Base/SPOnlineConnectionHelper.cs
@@ -622,7 +622,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
                         context.ExecuteQueryRetry();
                     }
 #if !ONPREMISES
-                    catch (NotSupportedException nox)
+                    catch (NotSupportedException)
                     {
 #if NETSTANDARD2_1
                         // Legacy auth is not supported with .NET Standard
@@ -860,15 +860,15 @@ namespace SharePointPnP.PowerShell.Commands.Base
                     return true;
                 }
             }
-            catch (ClientRequestException x1)
+            catch (ClientRequestException)
             {
                 return false;
             }
-            catch (ServerException x2)
+            catch (ServerException)
             {
                 return false;
             }
-            catch (WebException x3)
+            catch (WebException)
             {
                 return false;
             }

--- a/Commands/Branding/AddJavaScriptBlock.cs
+++ b/Commands/Branding/AddJavaScriptBlock.cs
@@ -41,7 +41,9 @@ namespace SharePointPnP.PowerShell.Commands.Branding
             // Following code to handle deprecated parameter
             CustomActionScope setScope;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (ParameterSpecified(nameof(SiteScoped)))
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 setScope = CustomActionScope.Site;
             }

--- a/Commands/Branding/AddJavaScriptLink.cs
+++ b/Commands/Branding/AddJavaScriptLink.cs
@@ -41,7 +41,9 @@ namespace SharePointPnP.PowerShell.Commands.Branding
             // Following code to handle deprecated parameter
             CustomActionScope setScope;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (ParameterSpecified(nameof(SiteScoped)))
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 setScope = CustomActionScope.Site;
             }

--- a/Commands/Branding/DisableResponsiveUI.cs
+++ b/Commands/Branding/DisableResponsiveUI.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 
@@ -10,6 +11,7 @@ namespace SharePointPnP.PowerShell.Commands.Branding
     [CmdletExample(Code = "PS:> Disable-PnPResponsiveUI",
         Remarks = @"If enabled previously, this will remove the PnP Responsive UI from a site.",
         SortOrder = 1)]
+    [Obsolete("The PnP responsive UI (classic view) has been deprecated.")]
     public class DisableResponsiveUI : PnPWebCmdlet
     {
         protected override void ExecuteCmdlet()

--- a/Commands/Branding/EnableResponsiveUI.cs
+++ b/Commands/Branding/EnableResponsiveUI.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 
@@ -10,8 +11,8 @@ namespace SharePointPnP.PowerShell.Commands.Branding
     [CmdletExample(
         Code = "PS:> Enable-PnPResponsiveUI",
         SortOrder = 1,
-        Remarks = "Will upload a CSS file, a JavaScript file and adds a custom action to the root web of the current site collection, enabling the responsive UI on the site collection. The CSS and JavaScript files are located in the style library, in a folder called SP.Responsive.UI.")]
-
+        Remarks = "Will upload a CSS file, a JavaScript file and adds a custom action to the root web of the current site collection, enabling the responsive UI on the site collection. The CSS and JavaScript files are located in the style library, in a folder called SP.Responsive.UI.")]    
+    [Obsolete("The PnP responsive UI (classic view) has been deprecated.")]
     public class EnableResponsiveUI : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "A full URL pointing to an infrastructure site. If specified, it will add a custom action pointing to the responsive UI JS code in that site.")]

--- a/Commands/Branding/RemoveJavaScriptLink.cs
+++ b/Commands/Branding/RemoveJavaScriptLink.cs
@@ -50,7 +50,9 @@ namespace SharePointPnP.PowerShell.Commands.Branding
         protected override void ExecuteCmdlet()
         {
             // Following code to handle deprecated parameter
+#pragma warning disable CS0618 // Type or member is obsolete
             if (ParameterSpecified(nameof(FromSite)))
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 Scope = CustomActionScope.Site;
             }

--- a/Commands/Provisioning/Site/NewProvisioningTemplateFromFolder.cs
+++ b/Commands/Provisioning/Site/NewProvisioningTemplateFromFolder.cs
@@ -207,7 +207,52 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
             if (!AsIncludeFile) return xml;
             XElement xElement = XElement.Parse(xml);
             // Get the Files Element
-            XNamespace pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2017_05;
+
+            XNamespace pnp = null;
+            switch (Schema)
+            {
+                case XMLPnPSchemaVersion.V201503:
+#pragma warning disable CS0618 // Type or member is obsolete
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_03;
+                    break;
+                case XMLPnPSchemaVersion.V201505:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_05;
+                    break;
+                case XMLPnPSchemaVersion.V201508:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_08;
+                    break;
+                case XMLPnPSchemaVersion.V201512:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2015_12;
+                    break;
+                case XMLPnPSchemaVersion.V201605:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05;
+                    break;
+                case XMLPnPSchemaVersion.V201705:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2017_05;
+                    break;
+                case XMLPnPSchemaVersion.V201801:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2018_01;
+                    break;
+                case XMLPnPSchemaVersion.V201805:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2018_05;
+#pragma warning restore CS0618 // Type or member is obsolete
+                    break;
+                case XMLPnPSchemaVersion.V201807:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2018_07;
+                    break;
+                case XMLPnPSchemaVersion.V201903:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2019_03;
+                    break;
+                case XMLPnPSchemaVersion.V201909:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2019_09;
+                    break;
+                case XMLPnPSchemaVersion.V202002:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2020_02;
+                    break;
+                default:
+                    pnp = XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2020_02;
+                    break;
+            }
 
             var filesElement = xElement.Descendants(pnp + "Files").FirstOrDefault();
             if (filesElement != null)

--- a/Commands/Provisioning/Site/NewProvisioningTemplateFromFolder.cs
+++ b/Commands/Provisioning/Site/NewProvisioningTemplateFromFolder.cs
@@ -208,7 +208,7 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
             XElement xElement = XElement.Parse(xml);
             // Get the Files Element
 
-            XNamespace pnp = null;
+            XNamespace pnp;
             switch (Schema)
             {
                 case XMLPnPSchemaVersion.V201503:
@@ -264,11 +264,13 @@ namespace SharePointPnP.PowerShell.Commands.Provisioning
 
         private string GetFiles(XMLPnPSchemaVersion schema, string folder, string ctid)
         {
-            ProvisioningTemplate template = new ProvisioningTemplate();
-            template.Id = "FOLDEREXPORT";
-            template.Security = null;
-            template.Features = null;
-            template.ComposedLook = null;
+            ProvisioningTemplate template = new ProvisioningTemplate
+            {
+                Id = "FOLDEREXPORT",
+                Security = null,
+                Features = null,
+                ComposedLook = null
+            };
 
             template.Files.AddRange(EnumerateFiles(folder, ctid, Properties));
 

--- a/Commands/RecordsManagement/SetInPlaceRecordsManagement.cs
+++ b/Commands/RecordsManagement/SetInPlaceRecordsManagement.cs
@@ -50,7 +50,9 @@ namespace SharePointPnP.PowerShell.Commands.RecordsManagement
             else
             {
                 // obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (ParameterSpecified(nameof(On)))
+#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     ClientContext.Site.ActivateInPlaceRecordsManagementFeature();
                 }

--- a/Commands/Site/SetSite.cs
+++ b/Commands/Site/SetSite.cs
@@ -344,7 +344,9 @@ namespace SharePointPnP.PowerShell.Commands.Site
                 DisableFlows.HasValue ||
                 DisableSharingForNonOwners.IsPresent ||
                 LocaleId.HasValue ||
+#pragma warning disable CS0618 // Type or member is obsolete
                 !string.IsNullOrEmpty(NewUrl) ||
+#pragma warning restore CS0618 // Type or member is obsolete
                 RestrictedToGeo.HasValue ||
                 SocialBarOnSitePagesDisabled.HasValue;
     }

--- a/Commands/Utilities/IsolatedStorage.cs
+++ b/Commands/Utilities/IsolatedStorage.cs
@@ -16,7 +16,7 @@ namespace SharePointPnP.PowerShell.Commands.Utilities
             {
                 var usfdAttempt1 = System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForDomain(); // this will fail when the current AppDomain Evidence is instantiated via COM or in PowerShell
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 useNewEvidence = true;
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##

Fixed compiler warnings.
Fixed bug in New-PnPProvisioningTemplateFromFolder where an old schema was always used and resulted in the functionality not working as expected.
Marked Enable-PnPResponsiveUI and Disable-PnPResponsiveUI as obsolete as the underlying functionality in PnP Sites Core has been deprecated for more than a year now (this generated a compiler warning too).